### PR TITLE
Reusable Preconditions in an embeddable form.

### DIFF
--- a/Google.Common/Google.Common.sln
+++ b/Google.Common/Google.Common.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{5C0B24F7-1AC8-4F40-ADDC-423084FFE377}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{86DA8FD9-CA01-4EFE-9A74-676438F2030A}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+		NuGet.Config = NuGet.Config
+	EndProjectSection
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Common.Embeddable", "src\Google.Common.Embeddable\Google.Common.Embeddable.xproj", "{939EE9F1-9F98-441B-851C-4B0F56F177BD}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Common.Tests", "src\Google.Common.Tests\Google.Common.Tests.xproj", "{114A853B-9616-477B-8CA6-B67A578A0CCA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{939EE9F1-9F98-441B-851C-4B0F56F177BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{939EE9F1-9F98-441B-851C-4B0F56F177BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{939EE9F1-9F98-441B-851C-4B0F56F177BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{939EE9F1-9F98-441B-851C-4B0F56F177BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{114A853B-9616-477B-8CA6-B67A578A0CCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{114A853B-9616-477B-8CA6-B67A578A0CCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{114A853B-9616-477B-8CA6-B67A578A0CCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{114A853B-9616-477B-8CA6-B67A578A0CCA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{939EE9F1-9F98-441B-851C-4B0F56F177BD} = {5C0B24F7-1AC8-4F40-ADDC-423084FFE377}
+		{114A853B-9616-477B-8CA6-B67A578A0CCA} = {5C0B24F7-1AC8-4F40-ADDC-423084FFE377}
+	EndGlobalSection
+EndGlobal

--- a/Google.Common/NuGet.Config
+++ b/Google.Common/NuGet.Config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/Google.Common/README.md
+++ b/Google.Common/README.md
@@ -1,0 +1,14 @@
+Google.Common libraries
+---
+
+Nothing in this directory is fixed - including the naming, package
+structure, or even which repository it will end up in.
+
+The `Google.Common.Embeddable` project is intended to include core
+classes which can be embedded directly into other projects using a
+dependency with type "build" in `project.json`. As such, it is
+possible that multiple copies may end up being loaded in a single
+application - the project should remain as small as possible; it
+only exists to avoid duplication. The types within this project are
+currently all internal.
+

--- a/Google.Common/global.json
+++ b/Google.Common/global.json
@@ -1,0 +1,6 @@
+﻿{
+  "projects": [ "src", "test" ],
+  "sdk": {
+    "version": "1.0.0-rc1-final"
+  }
+}

--- a/Google.Common/src/Google.Common.Embeddable/Google.Common.Embeddable.xproj
+++ b/Google.Common/src/Google.Common.Embeddable/Google.Common.Embeddable.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>939ee9f1-9f98-441b-851c-4b0f56f177bd</ProjectGuid>
+    <RootNamespace>Google.Common</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/Google.Common/src/Google.Common.Embeddable/Preconditions.cs
+++ b/Google.Common/src/Google.Common.Embeddable/Preconditions.cs
@@ -1,6 +1,13 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+// Note that this code file may be included directly in other projects
+// either using the DNX build system with a dependency with "type": "build",
+// or by copying and pasting. For the latter approach, developers should regularly
+// review the original code at
+// http://github.com/GoogleCloudPlatform/gcloud-dotnet/tree/master/Google.Common/src/Preconditions.cs
+// for changes.
+
 using System;
 
 namespace Google.Common

--- a/Google.Common/src/Google.Common.Embeddable/Preconditions.cs
+++ b/Google.Common/src/Google.Common.Embeddable/Preconditions.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using System;
+
+namespace Google.Common
+{
+    /// <summary>
+    /// Preconditions for checking method arguments, state etc.
+    /// </summary>
+    internal static class Preconditions
+    {
+        // Possible future directions:
+        // - Debug-only preconditions, as used extensively in Noda Time (for checking and self-documenting internal assumptions)
+        // - Methods that return null or "something that will throw an exception" to be chained with string interpolation
+        // - Methods accepting a string format and one or two arguments (to avoid any arrays being created at execution time,
+        //   but still allow for string formatting)
+        // - Conditional public/internal access, so that we can create a Google.Common assembly exposing all of this publicly, without
+        //   duplication.
+
+        /// <summary>
+        /// Checks that the given argument (to the calling method) is non-null.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="argument"></param>
+        /// <param name="paramName">The name of the parameter in the calling method.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="argument"/> is null</exception>
+        /// <returns><paramref name="argument"/> if it is not null</returns>
+        internal static T CheckNotNull<T>(this T argument, string paramName) where T : class
+        {
+            if (argument == null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+            return argument;
+        }
+
+        /// <summary>
+        /// Checks that the given argument value is valid.
+        /// </summary>
+        /// <remarks>
+        /// Note that the upper bound (<paramref name="maxExclusive"/>) is inclusive,
+        /// not exclusive. This is deliberate, to allow the specification of ranges which include
+        /// <see cref="Int32.MaxValue"/>.
+        /// </remarks>
+        /// <param name="argument">The value of the argument passed to the calling method.</param>
+        /// <param name="paramName">The name of the parameter in the calling method.</param>
+        /// <param name="minInclusive">The smallest valid value.</param>
+        /// <param name="maxInclusive">The largest valid value.</param>
+        /// <exception cref="ArgumentOutOfRangeException">The argument was outside the specified range.</exception>
+        internal static void CheckArgumentRange(int argument, string paramName, int minInclusive, int maxInclusive)
+        {
+            if (argument < minInclusive || argument > maxInclusive)
+            {
+                throw new ArgumentOutOfRangeException(paramName, $"Value {argument} should be in range [{minInclusive}, {maxInclusive}]");
+            }
+        }
+
+        /// <summary>
+        /// Checks that given condition is met, throwing an <see cref="InvalidOperationException"/> otherwise.
+        /// </summary>
+        /// <param name="condition">The condition to test.</param>
+        /// <param name="message">The message to include in the exception, if generated. This should not
+        /// use interpolation, as the interpolation would be performed regardless of whether or not an exception is thrown.</param>
+        internal static void CheckState(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+    }
+}

--- a/Google.Common/src/Google.Common.Embeddable/Preconditions.cs
+++ b/Google.Common/src/Google.Common.Embeddable/Preconditions.cs
@@ -69,5 +69,36 @@ namespace Google.Common
                 throw new InvalidOperationException(message);
             }
         }
+
+        /// <summary>
+        /// Checks that given condition is met, throwing an <see cref="InvalidOperationException"/> otherwise.
+        /// </summary>
+        /// <param name="condition">The condition to test.</param>
+        /// <param name="format">The format string to use to create the exception message if the
+        /// condition is not met.</param>
+        /// <param name="arg0">The argument to the format string.</param>
+        internal static void CheckState<T>(bool condition, string format, T arg0)
+        {
+            if (!condition)
+            {
+                throw new InvalidOperationException(string.Format(format, arg0));
+            }
+        }
+
+        /// <summary>
+        /// Checks that given condition is met, throwing an <see cref="InvalidOperationException"/> otherwise.
+        /// </summary>
+        /// <param name="condition">The condition to test.</param>
+        /// <param name="format">The format string to use to create the exception message if the
+        /// condition is not met.</param>
+        /// <param name="arg0">The first argument to the format string.</param>
+        /// <param name="arg1">The second argument to the format string.</param>
+        internal static void CheckState<T1, T2>(bool condition, string format, T1 arg0, T2 arg1)
+        {
+            if (!condition)
+            {
+                throw new InvalidOperationException(string.Format(format, arg0, arg1));
+            }
+        }
     }
 }

--- a/Google.Common/src/Google.Common.Embeddable/project.json
+++ b/Google.Common/src/Google.Common.Embeddable/project.json
@@ -1,0 +1,19 @@
+﻿{
+  "version": "0.0.0-*",
+  "description": "Embeddable library of commonly-used code",
+  "authors": [ "Google" ],
+  "tags": [ "" ],
+  "projectUrl": "",
+  "licenseUrl": "",
+
+  "shared": "**/*.cs",
+
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": {
+      "dependencies": {
+        "System.Runtime": "4.0.21-beta-23516"
+      }
+    }
+  }
+}

--- a/Google.Common/src/Google.Common.Embeddable/project.json
+++ b/Google.Common/src/Google.Common.Embeddable/project.json
@@ -3,14 +3,14 @@
   "description": "Embeddable library of commonly-used code",
   "authors": [ "Google" ],
   "tags": [ "" ],
-  "projectUrl": "",
-  "licenseUrl": "",
+  "projectUrl": "http://github.com/GoogleCloudPlatform/gcloud-dotnet",
+  "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
 
   "shared": "**/*.cs",
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": {
+    "net451": { },
+    "dotnet5.4": {
       "dependencies": {
         "System.Runtime": "4.0.21-beta-23516"
       }

--- a/Google.Common/src/Google.Common.Tests/Google.Common.Tests.xproj
+++ b/Google.Common/src/Google.Common.Tests/Google.Common.Tests.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>114a853b-9616-477b-8ca6-b67a578a0cca</ProjectGuid>
+    <RootNamespace>Google.Common.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/Google.Common/src/Google.Common.Tests/PreconditionsTest.cs
+++ b/Google.Common/src/Google.Common.Tests/PreconditionsTest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+using NUnit.Framework;
+using System;
+
+namespace Google.Common.Tests
+{
+    public class PreconditionsTest
+    {
+        const int RangeMin = -4;
+        const int RangeMax = 5;
+
+        [Test]
+        public void CheckNotNull_Valid()
+        {
+            object x = new object();
+            Assert.AreSame(x, x.CheckNotNull(nameof(x)));
+        }
+
+        [Test]
+        public void CheckNotNull_Invalid()
+        {
+            object x = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => x.CheckNotNull(nameof(x)));
+            Assert.AreEqual(nameof(x), exception.ParamName);
+        }
+
+        [Test]
+        [TestCase(RangeMin, Description = "Minimum value")]
+        [TestCase((RangeMin + RangeMax) / 2, Description = "Non-boundary value")]
+        [TestCase(RangeMax, Description = "Maximum value")]
+        public void CheckRange_Valid(int value)
+        {
+            Preconditions.CheckArgumentRange(value, nameof(value), -4, 5); 
+        }
+
+        [Test]
+        [TestCase(RangeMin - 1)]
+        [TestCase(RangeMax + 1)]
+        public void CheckRange_Invalid(int value)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => Preconditions.CheckArgumentRange(value, nameof(value), -4, 5));
+        }
+
+        [Test]
+        public void CheckState_Valid()
+        {
+            Preconditions.CheckState(true, "Not used");
+        }
+
+        [Test]
+        public void CheckState_Invalid()
+        {
+            string message = "Exception message";
+            var exception = Assert.Throws<InvalidOperationException>(() => Preconditions.CheckState(true, message));
+            Assert.AreEqual(message, exception.Message);
+        }
+    }
+}

--- a/Google.Common/src/Google.Common.Tests/Properties/AssemblyInfo.cs
+++ b/Google.Common/src/Google.Common.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Google.Common.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Google.Common.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("114a853b-9616-477b-8ca6-b67a578a0cca")]

--- a/Google.Common/src/Google.Common.Tests/project.json
+++ b/Google.Common/src/Google.Common.Tests/project.json
@@ -1,0 +1,24 @@
+﻿{
+  "version": "0.0.0-*",
+  "description": "Google.Common.Tests Class Library",
+  "authors": [ "Jon" ],
+  "tags": [ "" ],
+  "projectUrl": "",
+  "licenseUrl": "",
+  "dependencies": {
+    "Google.Common.Embeddable": {
+      "version": "0.0.0-*",
+      "type": "build"
+    },
+    "NUnit": "3.0.0"
+  },
+
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": {
+      "dependencies": {
+        "System.Runtime.InteropServices": "4.0.21-beta-23302"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is still very experimental... and we won't be able to use it easily until it's in Nuget, although we can build local versions. It *doesn't* need signing, as it's only source code basically.

Expected use is for a dependency with `"type": "build"` which embeds the source code into the "calling" project.