### PR TITLE
Remove common FetchAllAsync method, but keep ListAllBucketsAsync.

### DIFF
--- a/Google.Apis.Common/src/Google.Apis.Common.Tests/PaginatorTest.cs
+++ b/Google.Apis.Common/src/Google.Apis.Common.Tests/PaginatorTest.cs
@@ -51,13 +51,6 @@ namespace Google.Apis.Common.Tests
             Assert.Equal(resource.AllItems, actual);
         }
 
-        [Theory, MemberData(nameof(AllResources))]
-        public async Task FetchAllAsync(PaginatedResource resource)
-        {
-            var actual = await PaginatedResource.Paginator.FetchAllAsync(new Request { Check = resource.RequestCheck }, resource.GetPageAsync);
-            Assert.Equal(resource.AllItems, actual);
-        }
-
         [Fact]
         public async Task Cancellation()
         {

--- a/Google.Apis.Common/src/Google.Apis.Common/Paginator.cs
+++ b/Google.Apis.Common/src/Google.Apis.Common/Paginator.cs
@@ -113,37 +113,6 @@ namespace Google.Apis.Common
             });
         }
 
-        /// <summary>
-        /// Eagerly (but asynchronously) fetches a complete set of resources, potentially making multiple requests.
-        /// </summary>
-        /// <param name="initialRequest">The initial request to send. If this contains a page token,
-        /// that token is maintained. This is also passed to the request provider along with a token
-        /// to provide another request. (The provider may build a new object, or modify the existing request.)</param>
-        /// <param name="responseFetcher">A function to asynchronously fetch a response containing a
-        /// page of results given a request. Must not be null.</param>
-        /// <returns>A sequence of resources, which are fetched asynchronously and a page at a time.</returns>
-        /// <param name="cancellationToken"></param>
-        /// <returns>A task </returns>
-        public async Task<IList<TResource>> FetchAllAsync(
-            TRequest initialRequest,
-            Func<TRequest, CancellationToken, Task<TResponse>> responseFetcher,
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
-            Preconditions.CheckNotNull(responseFetcher, nameof(responseFetcher));
-            List<TResource> results = new List<TResource>();
-            TToken token;
-            TRequest nextRequest = initialRequest;
-            do
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                TResponse response = await responseFetcher(nextRequest, cancellationToken).ConfigureAwait(false);
-                token = _tokenExtractor(response);
-                nextRequest = _requestProvider(initialRequest, token);
-                results.AddRange(_resourceExtractor(response));
-            } while (!IsEmptyToken(token));
-            return results;
-        }
-
         private bool IsEmptyToken(TToken token)
         {
             return EqualityComparer<TToken>.Default.Equals(token, _emptyToken);

--- a/GoogleApiWrappers/GoogleApiWrappers.sln
+++ b/GoogleApiWrappers/GoogleApiWrappers.sln
@@ -19,6 +19,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Apis.Storage.v1.Inte
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Common.Embeddable", "..\Google.Common\src\Google.Common.Embeddable\Google.Common.Embeddable.xproj", "{939EE9F1-9F98-441B-851C-4B0F56F177BD}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Apis.Common", "..\Google.Apis.Common\src\Google.Apis.Common\Google.Apis.Common.xproj", "{16E01144-C66A-4267-AE2C-40FECF562BBB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{939EE9F1-9F98-441B-851C-4B0F56F177BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{939EE9F1-9F98-441B-851C-4B0F56F177BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{939EE9F1-9F98-441B-851C-4B0F56F177BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16E01144-C66A-4267-AE2C-40FECF562BBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{16E01144-C66A-4267-AE2C-40FECF562BBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16E01144-C66A-4267-AE2C-40FECF562BBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{16E01144-C66A-4267-AE2C-40FECF562BBB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.cs
@@ -6,6 +6,7 @@ using Google.Apis.Services;
 using Google.Apis.Storage.v1.Data;
 using Google.Common;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -99,11 +100,43 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A list of all buckets within the project.</returns>
-        public Task<IList<Bucket>> ListAllBucketsAsync(string project, ListBucketsOptions options, CancellationToken cancellationToken)
+        public async Task<IList<Bucket>> ListAllBucketsAsync(string project, ListBucketsOptions options, CancellationToken cancellationToken)
+        {
+            Preconditions.CheckNotNull(project, nameof(project));
+            return await ListBucketsAsync(project, options).ToList(cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously lists the buckets for a given project.
+        /// </summary>
+        /// <remarks>
+        /// This lists the buckets within a project asynchronously and lazily.
+        /// </remarks>
+        /// <remarks>
+        /// This is a convenience method for calling <see cref="ListAllBucketsAsync(string, ListBucketsOptions, CancellationToken)"/>.
+        /// </remarks>
+        /// <param name="project">The project to list the buckets from. Must not be null.</param>
+        public IAsyncEnumerable<Bucket> ListBucketsAsync(string project)
+        {
+            Preconditions.CheckNotNull(project, nameof(project));
+            return ListBucketsAsync(project, null);
+        }
+
+        /// <summary>
+        /// Asynchronously lists the buckets for a given project.
+        /// </summary>
+        /// <remarks>
+        /// This lists the buckets within a project asynchronously and lazily.
+        /// </remarks>
+        /// <param name="project">The project to list the buckets from. Must not be null.</param>
+        /// <param name="options">The options for the operation. May be null, in which case
+        /// defaults will be supplied.</param>
+        /// <returns>A list of all buckets within the project.</returns>
+        public IAsyncEnumerable<Bucket> ListBucketsAsync(string project, ListBucketsOptions options)
         {
             Preconditions.CheckNotNull(project, nameof(project));
             var initialRequest = CreateRequest(project, options);
-            return s_paginator.FetchAllAsync(initialRequest, (req, token) => req.ExecuteAsync(token), cancellationToken);
+            return s_paginator.FetchAsync(initialRequest, (req, cancellationToken) => req.ExecuteAsync(cancellationToken));
         }
 
         /// <summary>


### PR DESCRIPTION
This is an alternative plan for issue #12, keeping redundancy only at the wrapper level.

Note that if we changed `ListAllBucketsAsync` to just return `Task<List<Bucket>>` we could make it a synchronous method. (`Task<T>` isn't covariant in `T`, and can't be because it's a class rather than a delegate or interface. Boo hiss.)

@ivannaranjo to review