### PR TITLE
Perform basic bucket name validation up-front

### DIFF
--- a/GoogleApiWrappers/GoogleApiWrappers.sln
+++ b/GoogleApiWrappers/GoogleApiWrappers.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{AC0CC83C-0448-419E-914E-E63036A77BD9}"
 EndProject
@@ -20,6 +20,8 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Common.Embeddable", "..\Google.Common\src\Google.Common.Embeddable\Google.Common.Embeddable.xproj", "{939EE9F1-9F98-441B-851C-4B0F56F177BD}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Apis.Common", "..\Google.Apis.Common\src\Google.Apis.Common\Google.Apis.Common.xproj", "{16E01144-C66A-4267-AE2C-40FECF562BBB}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Apis.Storage.v1.Tests", "src\Google.Apis.Storage.v1.Tests\Google.Apis.Storage.v1.Tests.xproj", "{C9B4D3E8-47C4-4498-BEFF-276060D1EA13}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,6 +49,10 @@ Global
 		{16E01144-C66A-4267-AE2C-40FECF562BBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{16E01144-C66A-4267-AE2C-40FECF562BBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{16E01144-C66A-4267-AE2C-40FECF562BBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9B4D3E8-47C4-4498-BEFF-276060D1EA13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9B4D3E8-47C4-4498-BEFF-276060D1EA13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9B4D3E8-47C4-4498-BEFF-276060D1EA13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9B4D3E8-47C4-4498-BEFF-276060D1EA13}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -55,5 +61,6 @@ Global
 		{E8814844-5FA9-4F2B-AEAD-E7CE427DE48A} = {AC0CC83C-0448-419E-914E-E63036A77BD9}
 		{2BB8D957-102E-46BB-8EB4-5F29FBC1EA9D} = {AC0CC83C-0448-419E-914E-E63036A77BD9}
 		{077DDB17-CF46-4285-8853-D9AE576320F5} = {AC0CC83C-0448-419E-914E-E63036A77BD9}
+		{C9B4D3E8-47C4-4498-BEFF-276060D1EA13} = {AC0CC83C-0448-419E-914E-E63036A77BD9}
 	EndGlobalSection
 EndGlobal

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.DownloadObject.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.DownloadObject.cs
@@ -87,9 +87,9 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// </summary>
         private static string GetUri(string bucket, string sourceName)
         {
-            bucket.CheckNotNull(nameof(bucket));
+            ValidateBucket(bucket);
             sourceName.CheckNotNull(nameof(sourceName));
-            return $"https://www.googleapis.com/download/storage/v1/b/{Uri.EscapeDataString(bucket)}/o/{Uri.EscapeDataString(sourceName)}?alt=media";
+            return $"https://www.googleapis.com/download/storage/v1/b/{bucket}/o/{Uri.EscapeDataString(sourceName)}?alt=media";
         }
 
         /// <summary>

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.ListObjects.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.ListObjects.cs
@@ -79,7 +79,6 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// <returns>An asynchronus sequence of objects within the bucket.</returns>
         public IAsyncEnumerable<Object> ListObjectsAsync(string bucket, ListObjectsOptions options)
         {
-            Preconditions.CheckNotNull(bucket, nameof(bucket));
             var initialRequest = CreateListObjectsRequest(bucket, options);
             return s_objectPaginator.FetchAsync(initialRequest, (req, cancellationToken) => req.ExecuteAsync(cancellationToken));
         }
@@ -113,13 +112,13 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// <returns>A sequence of objects within the bucket.</returns>
         public IEnumerable<Object> ListObjects(string bucket, ListObjectsOptions options)
         {
-            Preconditions.CheckNotNull(bucket, nameof(bucket));
             var initialRequest = CreateListObjectsRequest(bucket, options);
             return s_objectPaginator.Fetch(initialRequest, req => req.Execute());
         }
 
         private ObjectsResource.ListRequest CreateListObjectsRequest(string bucket, ListObjectsOptions options)
         {
+            ValidateBucket(bucket);
             var request = Service.Objects.List(bucket);
             options?.ModifyRequest(request);
             return request;

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.cs
@@ -3,6 +3,8 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Common;
+using System;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Google.Apis.Storage.v1.ClientWrapper
@@ -61,6 +63,23 @@ namespace Google.Apis.Storage.v1.ClientWrapper
                 ApplicationName = applicationName,
             };
             return new StorageClient(initializer);
+        }
+
+        private static readonly Regex ValidBucketName = new Regex(@"^[0-9a-z.\-_]{1,222}$");
+
+        /// <summary>
+        /// Validates that a bucket only contains valid characters, and is not too long. This is far from
+        /// complete validation, but is all that's required to ensure that it's safe to include in a URL.
+        /// This method also checks for nullity, so callers don't need to do that first.
+        /// This method is internal rather than private for testing purposes.
+        /// </summary>
+        internal static void ValidateBucket(string bucket)
+        {
+            bucket.CheckNotNull(nameof(bucket));
+            if (!ValidBucketName.IsMatch(bucket))
+            {
+                throw new ArgumentException("Invalid bucket name - see https://cloud.google.com/storage/docs/bucket-naming", nameof(bucket));
+            }
         }
     }
 }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/DownloadObjectTest.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/DownloadObjectTest.cs
@@ -4,9 +4,7 @@
 using Google.Apis.Download;
 using Google.Apis.Storage.v1.ClientWrapper;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -83,6 +81,12 @@ namespace Google.Apis.Storage.v1.IntegrationTests
                     cts.Token,
                     progress));
             }
+        }
+
+        [Fact]
+        public void DownloadObjectFromInvalidBucket()
+        {
+            Assert.Throws<ArgumentException>(() => s_config.Client.DownloadObject("!!!", s_name, new MemoryStream()));
         }
     }
 }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/ListBucketsTest.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/ListBucketsTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
+
 using Google.Apis.Storage.v1.ClientWrapper;
 using Google.Apis.Storage.v1.Data;
 using System;

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/ListObjectsTest.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/ListObjectsTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
+
 using Google.Apis.Storage.v1.ClientWrapper;
-using Google.Apis.Storage.v1.Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/BucketValidationTest.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/BucketValidationTest.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using Google.Apis.Storage.v1.ClientWrapper;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Apis.Storage.v1.Tests
+{
+    public class BucketValidationTest
+    {
+        [Theory]
+        [InlineData("justtext")]
+        [InlineData("dots.dashes-and_underscores")]
+        [InlineData("numbers012346789")]
+        public void ValidBucketNames(string bucket)
+        {
+            StorageClient.ValidateBucket(bucket);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("UPPERCASE")]
+        [InlineData("spaces in name")]
+        [InlineData("invalid-punctuation1!")]
+        [InlineData("invalid-punctuation2/")]
+        [InlineData("invalid-punctuation3\\")]
+        [InlineData("invalid-punctuation4\"")]
+        [InlineData("invalid-punctuation5$")]
+        [InlineData("invalid-punctuation6%")]
+        public void InvalidBucketNames(string bucket)
+        {
+            var exception = Assert.ThrowsAny<ArgumentException>(() => StorageClient.ValidateBucket(bucket));
+            Assert.Equal("bucket", exception.ParamName);
+        }
+    }
+}

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/Google.Apis.Storage.v1.Tests.xproj
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/Google.Apis.Storage.v1.Tests.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>c9b4d3e8-47c4-4498-beff-276060d1ea13</ProjectGuid>
+    <RootNamespace>Google.Apis.Storage.v1.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/Properties/AssemblyInfo.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Google.Apis.Storage.v1.ClientWrapper")]
+[assembly: AssemblyTitle("Google.Apis.Storage.v1.Tests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Google.Apis.Storage.v1.ClientWrapper")]
+[assembly: AssemblyProduct("Google.Apis.Storage.v1.Tests")]
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -20,6 +20,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("e8814844-5fa9-4f2b-aead-e7ce427de48a")]
-
-[assembly: InternalsVisibleTo("Google.Apis.Storage.v1.Tests")]
+[assembly: Guid("c9b4d3e8-47c4-4498-beff-276060d1ea13")]

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/project.json
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/project.json
@@ -1,0 +1,22 @@
+﻿{
+  "version": "0.0.0-*",
+  "description": "Unit tests for the Cloud Storage client wrapper library",
+  "authors": [ "googleapis-packages" ],
+  "tags": [ "" ],
+  "projectUrl": "",
+  "licenseUrl": "",
+
+  "dependencies": {
+    "Google.Apis.Storage.v1.ClientWrapper": "0.0.0-*",
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-rc1-build204"
+  },
+
+  "commands": {
+    "test": "xunit.runner.dnx"
+  },
+
+  "frameworks": {
+    "dnx451": { }
+  }
+}


### PR DESCRIPTION
We then don't need to encode the bucket name in the download link.

Fixes issue #25.