### PR TITLE
Make prefix a regular parameter on ListObjects.

### DIFF
--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/ListObjectsOptions.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/ListObjectsOptions.cs
@@ -8,11 +8,6 @@ namespace Google.Apis.Storage.v1.ClientWrapper
     /// </summary>
     public class ListObjectsOptions
     {
-        /// <summary>
-        /// The prefix to match. Only objects with names that start with this string will be returned.
-        /// </summary>
-        public string Prefix { get; set; }
-
         // TODO: We can't currently return both objects *and* prefixes. Should we have a separate ListPrefixes method?
         // Something more complex? It's unclear how common this is.
 
@@ -34,10 +29,6 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// <param name="request">The request to modify</param>
         internal void ModifyRequest(ObjectsResource.ListRequest request)
         {
-            if (Prefix != null)
-            {
-                request.Prefix = Prefix;
-            }
             if (PageSize != null)
             {
                 request.MaxResults = PageSize.Value;

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.ListObjects.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.ListObjects.cs
@@ -26,13 +26,15 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// Asynchronously lists the objects in a given bucket, returning the results as a list.
         /// </summary>
         /// <remarks>
-        /// This is a convenience method for calling <see cref="ListAllObjectsAsync(string, ListObjectsOptions, CancellationToken)"/>.
+        /// This is a convenience method for calling <see cref="ListAllObjectsAsync(string, string, ListObjectsOptions, CancellationToken)"/>.
         /// </remarks>
         /// <param name="bucket">The bucket to list the objects from. Must not be null.</param>
+        /// <param name="prefix">The prefix to match. Only objects with names that start with this string will be returned.
+        /// This parameter may be null, in which case no filtering is performed.</param>
         /// <returns>A list of objects within the bucket.</returns>
-        public Task<IList<Object>> ListAllObjectsAsync(string bucket)
+        public Task<IList<Object>> ListAllObjectsAsync(string bucket, string prefix)
         {
-            return ListAllObjectsAsync(bucket, null, default(CancellationToken));
+            return ListAllObjectsAsync(bucket, prefix, null, default(CancellationToken));
         }
 
         /// <summary>
@@ -43,13 +45,15 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// This does not support reporting progress, or streaming the results.
         /// </remarks>
         /// <param name="bucket">The bucket to list the objects from. Must not be null.</param>
+        /// <param name="prefix">The prefix to match. Only objects with names that start with this string will be returned.
+        /// This parameter may be null, in which case no filtering is performed.</param>
         /// <param name="options">The options for the operation. May be null, in which case
         /// defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A list of objects within the bucket.</returns>
-        public async Task<IList<Object>> ListAllObjectsAsync(string bucket, ListObjectsOptions options, CancellationToken cancellationToken)
+        public async Task<IList<Object>> ListAllObjectsAsync(string bucket, string prefix, ListObjectsOptions options, CancellationToken cancellationToken)
         {
-            return await ListObjectsAsync(bucket, options).ToList(cancellationToken);
+            return await ListObjectsAsync(bucket, prefix, options).ToList(cancellationToken);
         }
 
         /// <summary>
@@ -59,12 +63,14 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// This lists the objects within a bucket asynchronously and lazily.
         /// </remarks>
         /// <remarks>
-        /// This is a convenience method for calling <see cref="ListAllObjectsAsync(string, ListObjectsOptions, CancellationToken)"/>.
+        /// This is a convenience method for calling <see cref="ListAllObjectsAsync(string, string, ListObjectsOptions, CancellationToken)"/>.
         /// </remarks>
         /// <param name="bucket">The bucket to list the objects from. Must not be null.</param>
-        public IAsyncEnumerable<Object> ListObjectsAsync(string bucket)
+        /// <param name="prefix">The prefix to match. Only objects with names that start with this string will be returned.
+        /// This parameter may be null, in which case no filtering is performed.</param>
+        public IAsyncEnumerable<Object> ListObjectsAsync(string bucket, string prefix)
         {
-            return ListObjectsAsync(bucket, null);
+            return ListObjectsAsync(bucket, prefix, null);
         }
 
         /// <summary>
@@ -74,12 +80,14 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// This lists the objects within a bucket asynchronously and lazily.
         /// </remarks>
         /// <param name="bucket">The bucket to list the objects from. Must not be null.</param>
+        /// <param name="prefix">The prefix to match. Only objects with names that start with this string will be returned.
+        /// This parameter may be null, in which case no filtering is performed.</param>
         /// <param name="options">The options for the operation. May be null, in which case
         /// defaults will be supplied.</param>
         /// <returns>An asynchronus sequence of objects within the bucket.</returns>
-        public IAsyncEnumerable<Object> ListObjectsAsync(string bucket, ListObjectsOptions options)
+        public IAsyncEnumerable<Object> ListObjectsAsync(string bucket, string prefix, ListObjectsOptions options)
         {
-            var initialRequest = CreateListObjectsRequest(bucket, options);
+            var initialRequest = CreateListObjectsRequest(bucket, prefix, options);
             return s_objectPaginator.FetchAsync(initialRequest, (req, cancellationToken) => req.ExecuteAsync(cancellationToken));
         }
 
@@ -92,10 +100,12 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// simply call LINQ's <c>ToList()</c> method on the returned sequence.
         /// </remarks>
         /// <param name="bucket">The bucket to list the objects from. Must not be null.</param>
+        /// <param name="prefix">The prefix to match. Only objects with names that start with this string will be returned.
+        /// This parameter may be null, in which case no filtering is performed.</param>
         /// <returns>A sequence of objects within the bucket.</returns>
-        public IEnumerable<Object> ListObjects(string bucket)
+        public IEnumerable<Object> ListObjects(string bucket, string prefix)
         {
-            return ListObjects(bucket, null);
+            return ListObjects(bucket, prefix, null);
         }
 
         /// <summary>
@@ -107,19 +117,22 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// simply call LINQ's <c>ToList()</c> method on the returned sequence.
         /// </remarks>
         /// <param name="bucket">The bucket to list the objects from. Must not be null.</param>
+        /// <param name="prefix">The prefix to match. Only objects with names that start with this string will be returned.
+        /// This parameter may be null, in which case no filtering is performed.</param>
         /// <param name="options">The options for the operation. May be null, in which case
         /// defaults will be supplied.</param>
         /// <returns>A sequence of objects within the bucket.</returns>
-        public IEnumerable<Object> ListObjects(string bucket, ListObjectsOptions options)
+        public IEnumerable<Object> ListObjects(string bucket, string prefix, ListObjectsOptions options)
         {
-            var initialRequest = CreateListObjectsRequest(bucket, options);
+            var initialRequest = CreateListObjectsRequest(bucket, prefix, options);
             return s_objectPaginator.Fetch(initialRequest, req => req.Execute());
         }
 
-        private ObjectsResource.ListRequest CreateListObjectsRequest(string bucket, ListObjectsOptions options)
+        private ObjectsResource.ListRequest CreateListObjectsRequest(string bucket, string prefix, ListObjectsOptions options)
         {
             ValidateBucket(bucket);
             var request = Service.Objects.List(bucket);
+            request.Prefix = prefix;
             options?.ModifyRequest(request);
             return request;
         }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.Demo/Program.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.Demo/Program.cs
@@ -44,7 +44,8 @@ namespace Google.Apis.Storage.v1.Demo
                 config.Description = "List objects in a bucket";
                 config.HelpOption("-?|-h|--help");
                 var bucket = config.Argument("bucket", "Bucket to list objects from");
-                ConfigureForExecution(config, client => ListObjects(client, bucket.Value));
+                var prefix = config.Option("--prefix", "Prefix to match", CommandOptionType.SingleValue);
+                ConfigureForExecution(config, client => ListObjects(client, bucket.Value, prefix.Value()));
             });
             app.Command("download-object", config => {
                 config.HelpOption("-?|-h|--help");
@@ -95,9 +96,9 @@ namespace Google.Apis.Storage.v1.Demo
             return results.ForEachAsync(bucket => Console.WriteLine($"  {bucket.Name}"));
         }
 
-        private static Task ListObjects(StorageClient client, string bucket)
+        private static Task ListObjects(StorageClient client, string bucket, string prefix)
         {
-            var results = client.ListObjectsAsync(bucket, new ListObjectsOptions { PageSize = 3 });
+            var results = client.ListObjectsAsync(bucket, prefix, new ListObjectsOptions { PageSize = 3 });
             Console.WriteLine($"Objects in {bucket} (3 at a time):");
             return results.ForEachAsync(obj => Console.WriteLine($"  {obj.Name}"));
         }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/ListObjectsTest.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/ListObjectsTest.cs
@@ -26,7 +26,7 @@ namespace Google.Apis.Storage.v1.IntegrationTests
         public async Task AllObjects(int? pageSize)
         {
             var options = new ListObjectsOptions { PageSize = pageSize };
-            await AssertObjects(options, s_allObjectNames);
+            await AssertObjects(null, options, s_allObjectNames);
         }
 
         [Theory]
@@ -37,8 +37,8 @@ namespace Google.Apis.Storage.v1.IntegrationTests
         [InlineData("missing/", "")]
         public async Task PrefixAndDelimiter(string prefix, string expectedNames)
         {
-            var options = new ListObjectsOptions { Delimiter = "/", Prefix = prefix };
-            await AssertObjects(options, expectedNames.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries));
+            var options = new ListObjectsOptions { Delimiter = "/" };
+            await AssertObjects(prefix, options, expectedNames.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries));
         }
 
         [Fact]
@@ -52,13 +52,13 @@ namespace Google.Apis.Storage.v1.IntegrationTests
             await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await enumerator.MoveNext(cts.Token));
         }
 
-        private async Task AssertObjects(ListObjectsOptions options, string[] expectedNames)
+        private async Task AssertObjects(string prefix, ListObjectsOptions options, string[] expectedNames)
         {
-            var actual = s_config.Client.ListObjects(s_bucket, options);
+            var actual = s_config.Client.ListObjects(s_bucket, prefix, options);
             AssertObjectNames(actual, expectedNames);
-            actual = await s_config.Client.ListAllObjectsAsync(s_bucket, options, CancellationToken.None);
+            actual = await s_config.Client.ListAllObjectsAsync(s_bucket, prefix, options, CancellationToken.None);
             AssertObjectNames(actual, expectedNames);
-            actual = await s_config.Client.ListObjectsAsync(s_bucket, options).ToList(CancellationToken.None);
+            actual = await s_config.Client.ListObjectsAsync(s_bucket, prefix, options).ToList(CancellationToken.None);
             AssertObjectNames(actual, expectedNames);
         }
 


### PR DESCRIPTION
It was previously an option. Issue #17 suggests this is sufficiently common to merit promotion.
Note that this introduced inconsistency between ListObjects and ListBuckets, but I think that's okay - they're used in different ways.