### PR TITLE
Include the invalid bucket name within the exception message

### DIFF
--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.cs
@@ -78,7 +78,7 @@ namespace Google.Apis.Storage.v1.ClientWrapper
             bucket.CheckNotNull(nameof(bucket));
             if (!ValidBucketName.IsMatch(bucket))
             {
-                throw new ArgumentException("Invalid bucket name - see https://cloud.google.com/storage/docs/bucket-naming", nameof(bucket));
+                throw new ArgumentException($"Invalid bucket name '{bucket}' - see https://cloud.google.com/storage/docs/bucket-naming", nameof(bucket));
             }
         }
     }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/BucketValidationTest.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/BucketValidationTest.cs
@@ -33,6 +33,7 @@ namespace Google.Apis.Storage.v1.Tests
         {
             var exception = Assert.ThrowsAny<ArgumentException>(() => StorageClient.ValidateBucket(bucket));
             Assert.Equal("bucket", exception.ParamName);
+            Assert.Contains(bucket, exception.Message);
         }
     }
 }


### PR DESCRIPTION
This doesn't perform any escaping, but should be useful enough in most situations -
any bucket name that includes control characters is likely to be deliberately weird.