### PR TITLE
DeleteObject operation

### DIFF
--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/DeleteObjectOptions.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/DeleteObjectOptions.cs
@@ -1,0 +1,21 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+namespace Google.Apis.Storage.v1.ClientWrapper
+{
+    /// <summary>
+    /// Options for <c>DeleteObject</c> operations.
+    /// </summary>
+    public class DeleteObjectOptions
+    {
+        public long? Generation { get; set; }
+
+        internal void ModifyRequest(ObjectsResource.DeleteRequest request)
+        {
+            if (Generation != null)
+            {
+                request.Generation = Generation;
+            }
+        }
+    }
+}

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.DeleteObject.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.DeleteObject.cs
@@ -1,0 +1,262 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using Google.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+
+namespace Google.Apis.Storage.v1.ClientWrapper
+{
+    public partial class StorageClient
+    {
+        /// <summary>
+        /// Deletes the latest version of the specified object synchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the bucket containing the object supports versioning, after this operation
+        /// completes successfully there may still be another version of the same object, and the
+        /// deleted version will still be available (but marked as deleted). In buckets which
+        /// do not support versioning, this operation will permanently delete the object.
+        /// </para>
+        /// <para>
+        /// If the request attempts to delete an object that does not exist, this counts as a failure with an HTTP status code of 404.
+        /// </para>
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket containing the object. Must not be null.</param>
+        /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
+        public void DeleteObject(string bucket, string objectName)
+        {
+            DeleteObject(bucket, objectName, null);
+        }
+
+        /// <summary>
+        /// Deletes a version of the specified object synchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// By default this will delete the latest version of the object, but this can be
+        /// controlled using <see cref="DeleteObjectOptions.Generation"/>. For buckets that support
+        /// multiple versions, implicitly deleting the latest version only archives
+        /// it so the object is still available and can be listed by specifying <see cref="ListObjectsOptions.Versions"/>.
+        /// If the version is explicitly specified, the object is permanently deleted.
+        /// </para>
+        /// <para>
+        /// If the bucket containing the object supports versioning, after this operation
+        /// completes successfully there may still be another version of the same object. In buckets which
+        /// do not support versioning, this operation will permanently delete the object.
+        /// </para>
+        /// <para>
+        /// If the request attempts to delete an object that does not exist or a specific version that does
+        /// not exist, this counts as a failure with an HTTP status code of 404.
+        /// </para>
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket containing the object. Must not be null.</param>
+        /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate
+        /// defaults will be used.</param>
+        public void DeleteObject(string bucket, string objectName, DeleteObjectOptions options)
+        {
+            CreateDeleteObjectRequest(bucket, objectName, options).Execute();
+        }
+
+        /// <summary>
+        /// Deletes the latest version of the specified object asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the bucket containing the object supports versioning, after this operation
+        /// completes successfully there may still be another version of the same object, and the
+        /// deleted version will still be available (but marked as deleted). In buckets which
+        /// do not support versioning, this operation will permanently delete the object.
+        /// </para>
+        /// <para>
+        /// If the request attempts to delete an object that does not exist, this counts as a failure with an HTTP status code of 404.
+        /// </para>
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket containing the object. Must not be null.</param>
+        /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public Task DeleteObjectAsync(string bucket, string objectName)
+        {
+            return DeleteObjectAsync(bucket, objectName, null, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Deletes a version of the specified object asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// By default this will delete the latest version of the object, but this can be
+        /// controlled using <see cref="DeleteObjectOptions.Generation"/>. For buckets that support
+        /// multiple versions, implicitly deleting the latest version only archives
+        /// it so the object is still available and can be listed by specifying <see cref="ListObjectsOptions.Versions"/>.
+        /// If the version is explicitly specified, the object is permanently deleted.
+        /// </para>
+        /// <para>
+        /// If the bucket containing the object supports versioning, after this operation
+        /// completes successfully there may still be another version of the same object. In buckets which
+        /// do not support versioning, this operation will permanently delete the object.
+        /// </para>
+        /// <para>
+        /// If the request attempts to delete an object that does not exist or a specific version that does
+        /// not exist, this counts as a failure with an HTTP status code of 404.
+        /// </para>
+        /// </remarks>
+        /// <param name="bucket">The name of the bucket containing the object. Must not be null.</param>
+        /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate
+        /// defaults will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public Task DeleteObjectAsync(string bucket, string objectName, DeleteObjectOptions options, CancellationToken cancellationToken)
+        {
+            return CreateDeleteObjectRequest(bucket, objectName, options).ExecuteAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Deletes a version of the specified object synchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Note that any generation information contained within <paramref name="obj"/> is ignored;
+        /// this overload will always delete the latest version. Use <see cref="DeleteObject(Object, DeleteObjectOptions)"/>
+        /// if you wish to specify a particular version to delete.
+        /// If the bucket containing the object supports versioning, after this operation
+        /// completes successfully there may still be another version of the same object, and the
+        /// deleted version will still be available (but marked as deleted). In buckets which
+        /// do not support versioning, this operation will permanently delete the object.
+        /// </para>
+        /// <para>
+        /// If the bucket containing the object supports versioning, after this operation
+        /// completes successfully there may still be another version of the same object. In buckets which
+        /// do not support versioning, this operation will permanently delete the object.
+        /// </para>
+        /// <para>
+        /// If the request attempts to delete an object that does not exist, this counts as a failure with an HTTP status code of 404.
+        /// </para>
+        /// </remarks>
+        /// <param name="obj">Object to delete. Must not be null, and must have the name and bucket populated.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate
+        /// defaults will be used.</param>
+        public void DeleteObject(Object obj)
+        {
+            DeleteObject(obj, null);
+        }
+
+        /// <summary>
+        /// Deletes a version of the specified object synchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// By default this will delete the latest version of the object, but this can be
+        /// controlled using <see cref="DeleteObjectOptions.Generation"/>. Note that any generation information
+        /// contained within <paramref name="obj"/> is ignored; the generation to delete is only controlled
+        /// via <paramref name="options"/>. For buckets that support
+        /// multiple versions, implicitly deleting the latest version only archives
+        /// it so the object is still available and can be listed by specifying <see cref="ListObjectsOptions.Versions"/>.
+        /// If the version is explicitly specified, the object is permanently deleted.
+        /// </para>
+        /// <para>
+        /// If the bucket containing the object supports versioning, after this operation
+        /// completes successfully there may still be another version of the same object. In buckets which
+        /// do not support versioning, this operation will permanently delete the object.
+        /// </para>
+        /// <para>
+        /// If the request attempts to delete an object that does not exist or a specific version that does
+        /// not exist, this counts as a failure with an HTTP status code of 404.
+        /// </para>
+        /// </remarks>
+        /// <param name="obj">Object to delete. Must not be null, and must have the name and bucket populated.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate
+        /// defaults will be used.</param>
+        public void DeleteObject(Object obj, DeleteObjectOptions options)
+        {
+            CreateDeleteObjectRequest(obj, options).Execute();
+        }
+
+        /// <summary>
+        /// Deletes the latest version of the specified object asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Note that any generation information contained within <paramref name="obj"/> is ignored;
+        /// this overload will always delete the latest version. Use <see cref="DeleteObjectAsync(Object, DeleteObjectOptions)"/>
+        /// if you wish to specify a particular version to delete.
+        /// If the bucket containing the object supports versioning, after this operation
+        /// completes successfully there may still be another version of the same object, and the
+        /// deleted version will still be available (but marked as deleted). In buckets which
+        /// do not support versioning, this operation will permanently delete the object.
+        /// </para>
+        /// <para>
+        /// If the bucket containing the object supports versioning, after this operation
+        /// completes successfully there may still be another version of the same object. In buckets which
+        /// do not support versioning, this operation will permanently delete the object.
+        /// </para>
+        /// <para>
+        /// If the request attempts to delete an object that does not exist, this counts as a failure with an HTTP status code of 404.
+        /// </para>
+        /// </remarks>
+        /// <param name="obj">Object to delete. Must not be null, and must have the name and bucket populated.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate
+        /// defaults will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public Task DeleteObjectAsync(Object obj)
+        {
+            return DeleteObjectAsync(obj, null, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Deletes a version of the specified object asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// By default this will delete the latest version of the object, but this can be
+        /// controlled using <see cref="DeleteObjectOptions.Generation"/>. Note that any generation information
+        /// contained within <paramref name="obj"/> is ignored; the generation to delete is only controlled
+        /// via <paramref name="options"/>. For buckets that support
+        /// multiple versions, implicitly deleting the latest version only archives
+        /// it so the object is still available and can be listed by specifying <see cref="ListObjectsOptions.Versions"/>.
+        /// If the version is explicitly specified, the object is permanently deleted.
+        /// </para>
+        /// <para>
+        /// If the bucket containing the object supports versioning, after this operation
+        /// completes successfully there may still be another version of the same object. In buckets which
+        /// do not support versioning, this operation will permanently delete the object.
+        /// </para>
+        /// <para>
+        /// If the request attempts to delete an object that does not exist or a specific version that does
+        /// not exist, this counts as a failure with an HTTP status code of 404.
+        /// </para>
+        /// </remarks>
+        /// <param name="obj">Object to delete. Must not be null, and must have the name and bucket populated.</param>
+        /// <param name="options">Additional options for the operation. May be null, in which case appropriate
+        /// defaults will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public Task DeleteObjectAsync(Object obj, DeleteObjectOptions options, CancellationToken cancellationToken)
+        {
+            return CreateDeleteObjectRequest(obj, options).ExecuteAsync(cancellationToken);
+        }
+
+        private ObjectsResource.DeleteRequest CreateDeleteObjectRequest(Object obj, DeleteObjectOptions options)
+        {
+            ValidateObject(obj, nameof(obj));
+            var request = Service.Objects.Delete(obj.Bucket, obj.Name);
+            options?.ModifyRequest(request);
+            return request;
+        }
+
+        private ObjectsResource.DeleteRequest CreateDeleteObjectRequest(string bucket, string name, DeleteObjectOptions options)
+        {
+            ValidateBucket(bucket);
+            name.CheckNotNull(nameof(name));
+            var request = Service.Objects.Delete(bucket, name);
+            options?.ModifyRequest(request);
+            return request;
+        }
+    }
+}

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.UploadObject.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.UploadObject.cs
@@ -143,7 +143,7 @@ namespace Google.Apis.Storage.v1.ClientWrapper
             UploadObjectOptions options,
             IProgress<IUploadProgress> progress)
         {
-            ValidateObject(destination);
+            ValidateObject(destination, nameof(destination));
             source.CheckNotNull(nameof(source));
             var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
             options?.ModifyMediaUpload(mediaUpload);
@@ -178,7 +178,7 @@ namespace Google.Apis.Storage.v1.ClientWrapper
             CancellationToken cancellationToken,
             IProgress<IUploadProgress> progress)
         {
-            ValidateObject(destination);
+            ValidateObject(destination, nameof(destination));
             source.CheckNotNull(nameof(source));
             var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
             options?.ModifyMediaUpload(mediaUpload);
@@ -192,18 +192,6 @@ namespace Google.Apis.Storage.v1.ClientWrapper
                 throw finalProgress.Exception;
             }
             return mediaUpload.ResponseBody;
-        }
-
-        private void ValidateObject(Object destination)
-        {
-            destination.CheckNotNull(nameof(destination));
-            Preconditions.CheckArgument(
-                destination.Name != null && destination.Bucket != null && destination.ContentType != null,
-                nameof(destination),
-                "Destination object must have a name, bucket and content type");
-            Preconditions.CheckArgument(ValidBucketName.IsMatch(destination.Bucket),
-                nameof(destination),
-                "Destination bucket '{0}' is invalid", destination.Bucket);
         }
     }
 }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.cs
@@ -6,6 +6,7 @@ using Google.Common;
 using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Apis.Storage.v1.ClientWrapper
 {
@@ -84,6 +85,24 @@ namespace Google.Apis.Storage.v1.ClientWrapper
             {
                 throw new ArgumentException($"Invalid bucket name '{bucket}' - see https://cloud.google.com/storage/docs/bucket-naming", nameof(bucket));
             }
+        }
+
+
+        /// <summary>
+        /// Validates that the given Object has a "somewhat valid" (no URI encoding required) bucket name and an object name.
+        /// </summary>
+        /// <param name="obj">Object to validate</param>
+        /// <param name="paramName">The parameter name in the calling method</param>
+        private void ValidateObject(Object obj, string paramName)
+        {
+            obj.CheckNotNull(paramName);
+            Preconditions.CheckArgument(
+                obj.Name != null && obj.Bucket != null && obj.ContentType != null,
+                paramName,
+                "Destination object must have a name, bucket and content type");
+            Preconditions.CheckArgument(ValidBucketName.IsMatch(obj.Bucket),
+                paramName,
+                "Destination bucket '{0}' is invalid", obj.Bucket);
         }
     }
 }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.Demo/Program.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.Demo/Program.cs
@@ -73,6 +73,14 @@ namespace Google.Apis.Storage.v1.Demo
                 var name = config.Argument("name", "Name of object to fetch information about");
                 ConfigureForExecution(config, client => GetObject(client, bucket.Value, name.Value));
             });
+            app.Command("delete-object", config => {
+                config.HelpOption("-?|-h|--help");
+                config.Description = "Deletes the latest generation of an object from storage";
+                var bucket = config.Argument("bucket", "Bucket containing the object");
+                var name = config.Argument("name", "Name of object to delete");
+                var generation = config.Option("--generation", "Generation", CommandOptionType.SingleValue);
+                ConfigureForExecution(config, client => DeleteObject(client, bucket.Value, name.Value, generation.Value()));
+            });
 
             return app.Execute(args);
         }
@@ -151,6 +159,13 @@ namespace Google.Apis.Storage.v1.Demo
         {
             var obj = await client.GetObjectAsync(bucket, name);
             Console.WriteLine(JsonConvert.SerializeObject(obj, Formatting.Indented));
+        }
+
+        private static async Task DeleteObject(StorageClient client, string bucket, string name, string generation)
+        {
+            long? generationOption = generation == null ? default(long?) : long.Parse(generation);
+            await client.DeleteObjectAsync(bucket, name, new DeleteObjectOptions { Generation = generationOption }, CancellationToken.None);
+            Console.WriteLine($"Deleted object {bucket}/{name}");
         }
     }
 }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/DeleteObjectTest.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/DeleteObjectTest.cs
@@ -1,0 +1,144 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Object = Google.Apis.Storage.v1.Data.Object;
+using static Google.Apis.Storage.v1.IntegrationTests.TestHelpers;
+using Xunit;
+using Google.Apis.Storage.v1.ClientWrapper;
+using System.Net;
+
+namespace Google.Apis.Storage.v1.IntegrationTests
+{
+    public class DeleteObjectTest
+    {
+        private static readonly CloudConfiguration s_config = CloudConfiguration.Instance;
+
+        private static readonly string s_multiVersionBucket = s_config.TempBucketPrefix + "2";
+        private static readonly string s_singleVersionBucket = s_config.TempBucketPrefix + "3";
+
+        public static IEnumerable<object[]> BothBuckets => CreateTestData(s_multiVersionBucket, s_singleVersionBucket);
+
+        [Fact]
+        public void ImplicitLatestVersion_SingleVersionBucket()
+        {
+            var bucket = s_singleVersionBucket;
+            var name = CreateObjects(bucket, 1)[0].Name;
+            s_config.Client.DeleteObject(bucket, name);
+            Assert.Empty(ListObjects(bucket, name, true));
+        }
+
+        [Fact]
+        public void ImplicitLatestVersion_MultiVersionBucket()
+        {
+            var bucket = s_multiVersionBucket;
+            var name = CreateObjects(bucket, 1)[0].Name;
+            s_config.Client.DeleteObject(bucket, name);
+            // Without asking for versions, we don't get anything
+            Assert.Empty(ListObjects(bucket, name, false));
+            // If we ask for versions, we get the deleted object
+            var allVersions = ListObjects(bucket, name, true);
+            Assert.Equal(1, allVersions.Count);
+            Assert.NotNull(allVersions[0].TimeDeleted);
+        }
+
+        [Theory]
+        [MemberData(nameof(BothBuckets))]
+        public void SingleVersionObject_DeleteExplicitVersion(string bucket)
+        {
+            var obj = CreateObjects(bucket, 1)[0];
+            s_config.Client.DeleteObject(obj, new DeleteObjectOptions { Generation = obj.Generation });
+            Assert.Empty(ListObjects(obj, true));
+        }
+
+        [Theory]
+        [MemberData(nameof(BothBuckets))]
+        public void NonExistentObject(string bucket)
+        {
+            var exception = Assert.Throws<GoogleApiException>(() => s_config.Client.DeleteObject(bucket, GenerateName()));
+            Assert.Equal(HttpStatusCode.NotFound, exception.HttpStatusCode);
+        }
+
+        [Theory]
+        [MemberData(nameof(BothBuckets))]
+        public void WrongGeneration(string bucket)
+        {
+            var obj = CreateObjects(bucket, 1)[0];
+            var options = new DeleteObjectOptions { Generation = obj.Generation.Value + 1 };
+            var exception = Assert.Throws<GoogleApiException>(() => s_config.Client.DeleteObject(obj, options));
+            Assert.Equal(HttpStatusCode.NotFound, exception.HttpStatusCode);
+        }
+
+        [Theory]
+        [MemberData(nameof(BothBuckets))]
+        public void DeleteSameGenerationTwice(string bucket)
+        {
+            var obj = CreateObjects(bucket, 1)[0];
+            var options = new DeleteObjectOptions { Generation = obj.Generation.Value };
+            // First time is fine
+            s_config.Client.DeleteObject(obj, options);
+            // Second time throws an exception
+            var exception = Assert.Throws<GoogleApiException>(() => s_config.Client.DeleteObject(obj, options));
+            Assert.Equal(HttpStatusCode.NotFound, exception.HttpStatusCode);
+        }
+
+        [Fact]
+        public void DeleteImplicitlyThenExplicitly()
+        {
+            var bucket = s_multiVersionBucket;
+            var obj = CreateObjects(bucket, 1)[0];
+            s_config.Client.DeleteObject(obj);
+            s_config.Client.DeleteObject(obj, new DeleteObjectOptions { Generation = obj.Generation.Value });
+            Assert.Empty(ListObjects(obj, true));
+        }
+
+        [Fact]
+        public void MultipleVersionsCreated_SingleVersionBucket()
+        {
+            var bucket = s_singleVersionBucket;
+            var obj = CreateObjects(bucket, 3)[0];
+            s_config.Client.DeleteObject(obj);
+            Assert.Empty(ListObjects(obj, true));
+        }
+
+        [Fact]
+        public void MultipleVersionsCreated_MultiVersionBucket()
+        {
+            var bucket = s_multiVersionBucket;
+            var objects = CreateObjects(bucket, 3);
+            for (int i = 0; i < 3; i++)
+            {
+                var options = new DeleteObjectOptions { Generation = objects[i].Generation };
+                s_config.Client.DeleteObject(objects[0], options);
+                Assert.Equal(2 - i, ListObjects(objects[0], true).Count);
+            }
+        }
+
+        private static List<Object> ListObjects(Object obj, bool versions)
+        {
+            return ListObjects(obj.Bucket, obj.Name, versions);
+        }
+
+        private static List<Object> ListObjects(string bucket, string name, bool versions)
+        {
+            // Use the same prefix as the name - filtering to be certain later.
+            return s_config.Client.ListObjects(bucket, name, new ListObjectsOptions { Versions = versions })
+                .Where(o => o.Name == name)
+                .ToList();
+        }
+
+        private static List<Object> CreateObjects(string bucket, int versionCount)
+        {
+            string name = GenerateName();
+            var objects = new List<Object>();
+            for (int i = 0; i < versionCount; i++)
+            {
+                objects.Add(s_config.Client.UploadObject(bucket, name, "", GenerateData(i * 10)));
+            }
+            return objects;
+        }
+    }
+}

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/TestHelpers.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/TestHelpers.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace Google.Apis.Storage.v1.IntegrationTests
+{
+    internal static class TestHelpers
+    {
+        /// <summary>
+        /// Generates an object name which can reasonably be expected to be unique.
+        /// </summary>
+        internal static string GenerateName()
+        {
+            return Guid.NewGuid().ToString();
+        }
+
+        /// <summary>
+        /// Generates a read-only stream of random data of the given size. The
+        /// returned stream is positioned at the start of the data.
+        /// </summary>
+        internal static MemoryStream GenerateData(int size)
+        {
+            var rng = RandomNumberGenerator.Create();
+            byte[] data = new byte[size];
+            rng.GetBytes(data);
+            return new MemoryStream(data);
+        }
+
+        /// <summary>
+        /// Helper method for MemberDataAttribute, which required that the member is compatible
+        /// with IEnumerable{object[]}, unhelpfully :(
+        /// </summary>
+        internal static IEnumerable<object[]> CreateTestData<T>(params T[] values)
+        {
+            return values.Select(x => new object[] { x });
+        }
+    }
+}

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/UploadObjectTest.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/UploadObjectTest.cs
@@ -6,10 +6,10 @@ using Google.Apis.Upload;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using static Google.Apis.Storage.v1.IntegrationTests.TestHelpers;
 using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Apis.Storage.v1.IntegrationTests
@@ -97,19 +97,6 @@ namespace Google.Apis.Storage.v1.IntegrationTests
             var firstGenerationData = new MemoryStream();
             s_config.Client.DownloadObject(firstVersion, firstGenerationData);
             Assert.Equal(source1.ToArray(), firstGenerationData.ToArray());
-        }
-
-        private static string GenerateName()
-        {
-            return Guid.NewGuid().ToString();
-        }
-
-        private static MemoryStream GenerateData(int size)
-        {
-            var rng = RandomNumberGenerator.Create();
-            byte[] data = new byte[size];
-            rng.GetBytes(data);
-            return new MemoryStream(data);
         }
 
         private static void ValidateData(MemoryStream original, string objectName)


### PR DESCRIPTION
This is designed to propagate the existing API behavior around versioning etc, rather than imposing anything new.