### PR TITLE
Allow generation to be specified in DownloadObject

### DIFF
--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/DownloadObjectOptions.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/DownloadObjectOptions.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Download;
+using System;
+using System.Diagnostics;
+using System.Globalization;
 
 namespace Google.Apis.Storage.v1.ClientWrapper
 {
@@ -10,13 +13,16 @@ namespace Google.Apis.Storage.v1.ClientWrapper
     /// </summary>
     public class DownloadObjectOptions
     {
-        // TODO: Retry policy? There's not an awful lot else to specify.
-        // 
-
         /// <summary>
         /// The chunk size to use for each request.
         /// </summary>
         public int? ChunkSize;
+
+        /// <summary>
+        /// The generation to download. When not specified, the latest version
+        /// is always downloaded.
+        /// </summary>
+        public long? Generation;
 
         internal void ModifyDownloader(MediaDownloader downloader)
         {
@@ -24,6 +30,24 @@ namespace Google.Apis.Storage.v1.ClientWrapper
             {
                 downloader.ChunkSize = ChunkSize.Value;
             }
+        }
+
+        /// <summary>
+        /// Returns the URI to use for a download request, appending any options specified by this object.
+        /// </summary>
+        /// <param name="baseUri">Base URI which must end with a query parameter.</param>
+        /// <returns>The URI including the specified options.</returns>
+        internal string GetUri(string baseUri)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(new Uri(baseUri).Query));
+            string uri = MaybeAppendParameter(baseUri, "generation", Generation);
+            // Further calls would be uri = MaybeAppendParameter(baseUri, "...", SomeProperty)
+            return uri;
+        }        
+
+        private static string MaybeAppendParameter(string uri, string name, long? value)
+        {
+            return value == null ? uri : $"{uri}&{name}={value.Value.ToString(CultureInfo.InvariantCulture)}";
         }
     }
 }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.UploadObject.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.UploadObject.cs
@@ -144,6 +144,7 @@ namespace Google.Apis.Storage.v1.ClientWrapper
             IProgress<IUploadProgress> progress)
         {
             ValidateObject(destination, nameof(destination));
+            Preconditions.CheckArgument(destination.ContentType != null, nameof(destination), "Object must have a ContentType");
             source.CheckNotNull(nameof(source));
             var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
             options?.ModifyMediaUpload(mediaUpload);
@@ -179,6 +180,7 @@ namespace Google.Apis.Storage.v1.ClientWrapper
             IProgress<IUploadProgress> progress)
         {
             ValidateObject(destination, nameof(destination));
+            Preconditions.CheckArgument(destination.ContentType != null, nameof(destination), "Object must have a ContentType");
             source.CheckNotNull(nameof(source));
             var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
             options?.ModifyMediaUpload(mediaUpload);

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.cs
@@ -97,12 +97,12 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         {
             obj.CheckNotNull(paramName);
             Preconditions.CheckArgument(
-                obj.Name != null && obj.Bucket != null && obj.ContentType != null,
+                obj.Name != null && obj.Bucket != null,
                 paramName,
-                "Destination object must have a name, bucket and content type");
+                "Object must have a name and bucket");
             Preconditions.CheckArgument(ValidBucketName.IsMatch(obj.Bucket),
                 paramName,
-                "Destination bucket '{0}' is invalid", obj.Bucket);
+                "Object bucket '{0}' is invalid", obj.Bucket);
         }
     }
 }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/DownloadObjectTest.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/DownloadObjectTest.cs
@@ -5,6 +5,7 @@ using Google.Apis.Download;
 using Google.Apis.Storage.v1.ClientWrapper;
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -82,6 +83,63 @@ namespace Google.Apis.Storage.v1.IntegrationTests
         public void DownloadObjectFromInvalidBucket()
         {
             Assert.Throws<ArgumentException>(() => s_config.Client.DownloadObject("!!!", s_name, new MemoryStream()));
+        }
+
+        [Fact(Skip = "Waiting for change in MediaDownloader to land in NuGet")]
+        public void DownloadObjectWrongGeneration()
+        {
+            var existing = GetExistingObject();
+            var stream = new MemoryStream();
+            Assert.Throws<ArgumentException>(() => s_config.Client.DownloadObject(existing, stream,
+                new DownloadObjectOptions { Generation = existing.Generation + 1 }, null));
+            Assert.Equal(0, stream.Length);
+        }
+
+        [Fact]
+        public void DownloadDifferentGenerations()
+        {
+            var bucket = s_config.TempBucketPrefix + "0";
+            var name = "multiversion.txt";
+            var objects = s_config.Client.ListObjects(bucket, name, new ListObjectsOptions { Versions = true }).ToList();
+            Assert.Equal(2, objects.Count);
+
+            // Fetch them by generation and check size matches
+            foreach (var obj in objects)
+            {
+                var stream = new MemoryStream();
+                s_config.Client.DownloadObject(bucket, name, stream, new DownloadObjectOptions { Generation = obj.Generation }, null);
+                Assert.Equal((long) obj.Size, stream.Length);
+            }
+        }
+
+        [Fact]
+        public void SpecifyingObjectSourceIgnoredGeneration()
+        {
+            var bucket = s_config.TempBucketPrefix + "0";
+            var name = "multiversion.txt";
+            var objects = s_config.Client.ListObjects(bucket, name, new ListObjectsOptions { Versions = true }).OrderBy(x => x.Generation).ToList();
+            Assert.Equal(2, objects.Count);
+            Assert.NotEqual(objects[0].Size, objects[1].Size);
+
+            var stream = new MemoryStream();
+            s_config.Client.DownloadObject(objects[0], stream);
+            Assert.Equal((long) objects[1].Size, stream.Length);
+        }
+
+        [Fact]
+        public void DownloadObjectRightGeneration()
+        {
+            var existing = GetExistingObject();
+            var stream = new MemoryStream();
+            s_config.Client.DownloadObject(existing, stream,
+                new DownloadObjectOptions { Generation = existing.Generation }, null);
+            Assert.NotEqual(0, stream.Length);
+        }
+
+        private Data.Object GetExistingObject()
+        {
+            var service = s_config.Client.Service;
+            return service.Objects.Get(s_bucket, s_name).Execute();
         }
     }
 }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/UploadObjectTest.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/UploadObjectTest.cs
@@ -95,7 +95,7 @@ namespace Google.Apis.Storage.v1.IntegrationTests
 
             // When we ask for the first generation, we get the original data back.
             var firstGenerationData = new MemoryStream();
-            s_config.Client.DownloadObject(firstVersion, firstGenerationData);
+            s_config.Client.DownloadObject(firstVersion, firstGenerationData, new DownloadObjectOptions { Generation = firstVersion.Generation }, null);
             Assert.Equal(source1.ToArray(), firstGenerationData.ToArray());
         }
 


### PR DESCRIPTION
This changes the behavior of DownloadObject(Object) to always download the latest version rather than the version in the object.
Basically, only the name and bucket of the argument is used now. (This is consistent with DeleteObject and GetObject.)