### PR TITLE
Support preconditions for upload and download based on generation/metageneration

### DIFF
--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/DownloadObjectOptions.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/DownloadObjectOptions.cs
@@ -24,6 +24,30 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// </summary>
         public long? Generation;
 
+        /// <summary>
+        /// Precondition for download: if the object's generation does not match the
+        /// given generation, it is not downloaded.
+        /// </summary>
+        public long? IfGenerationMatch;
+
+        /// <summary>
+        /// Precondition for download: if the object's generation matches the
+        /// given generation, it is not downloaded.
+        /// </summary>
+        public long? IfGenerationNotMatch;
+
+        /// <summary>
+        /// Precondition for download: if the object's meta-generation does not match the
+        /// given generation, it is not downloaded.
+        /// </summary>
+        public long? IfMetagenerationMatch;
+
+        /// <summary>
+        /// Precondition for download: if the object's meta-generation matches the
+        /// given generation, it is not downloaded.
+        /// </summary>
+        public long? IfMetagenerationNotMatch;
+
         internal void ModifyDownloader(MediaDownloader downloader)
         {
             if (ChunkSize != null)
@@ -39,9 +63,23 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         /// <returns>The URI including the specified options.</returns>
         internal string GetUri(string baseUri)
         {
+            // Note the use of ArgumentException here, as this will basically be the result of invalid
+            // options being passed to a public method.
+            if (IfGenerationMatch != null && IfGenerationNotMatch != null)
+            {
+                throw new ArgumentException($"Cannot specify {nameof(IfGenerationMatch)} and {nameof(IfGenerationNotMatch)} in the same options", "options");
+            }
+            if (IfMetagenerationMatch != null && IfMetagenerationNotMatch != null)
+            {
+                throw new ArgumentException($"Cannot specify {nameof(IfMetagenerationMatch)} and {nameof(IfMetagenerationNotMatch)} in the same options", "options");
+            }
+
             Debug.Assert(!string.IsNullOrEmpty(new Uri(baseUri).Query));
             string uri = MaybeAppendParameter(baseUri, "generation", Generation);
-            // Further calls would be uri = MaybeAppendParameter(baseUri, "...", SomeProperty)
+            uri = MaybeAppendParameter(uri, "ifGenerationMatch", IfGenerationMatch);
+            uri = MaybeAppendParameter(uri, "ifGenerationNotMatch", IfGenerationNotMatch);
+            uri = MaybeAppendParameter(uri, "ifMetagenerationMatch", IfMetagenerationMatch);
+            uri = MaybeAppendParameter(uri, "ifMetagenerationNotMatch", IfMetagenerationNotMatch);
             return uri;
         }        
 

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/project.json
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/project.json
@@ -7,14 +7,14 @@
   "licenseUrl": "",
 
   "dependencies": {
-    "Google.Apis.Auth": "1.9.3",
-    "Google.Apis.Storage.v1": "1.9.2.490",
+    "Google.Apis.Auth": "1.10.0",
+    "Google.Apis.Storage.v1": "1.10.0.550",
     "Google.Common.Embeddable": {
       "type": "build",
       "version": "0.0.0-*"
     },
     "Google.Apis.Common": "0.0.0-*",
-    "Google.Apis.Core": "1.9.3",
+    "Google.Apis.Core": "1.10.0",
     "Ix-Async": "1.2.5"
   },
   "frameworks": {

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.Demo/project.json
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.Demo/project.json
@@ -7,8 +7,8 @@
   "licenseUrl": "",
 
   "dependencies": {
-    "Google.Apis.Auth": "1.9.3",
-    "Google.Apis.Storage.v1": "1.9.2.490",
+    "Google.Apis.Auth": "1.10.0",
+    "Google.Apis.Storage.v1": "1.10.0.550",
     "Google.Apis.Storage.v1.ClientWrapper": "0.0.0-*",
     "Microsoft.Framework.CommandLineUtils.Sources": {
       "version": "1.0.0-*",


### PR DESCRIPTION
Initial commit handles just DownloadObject; once we're happy with that, I'll do the same thing for UploadObject.