### PR TITLE
Rename Paginator to PageStreamer as a more accurate description

### DIFF
--- a/Google.Apis.Common/src/Google.Apis.Common/PageStreamer.cs
+++ b/Google.Apis.Common/src/Google.Apis.Common/PageStreamer.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Google.Apis.Common
 {
     /// <summary>
-    /// A paginator is a helper to provide both synchronous and asynchronous pagination
+    /// A page streamer is a helper to provide both synchronous and asynchronous page streaming
     /// of a listable or queryable resource.
     /// </summary>
     /// <remarks>
@@ -29,7 +29,7 @@ namespace Google.Apis.Common
     /// <typeparam name="TRequest">The type of request used to fetch pages</typeparam>
     /// <typeparam name="TResponse">The type of response obtained when fetching pages</typeparam>
     /// <typeparam name="TToken">The type of the "next page token", which must be equatable to itself</typeparam>
-    public sealed class Paginator<TResource, TRequest, TResponse, TToken>
+    public sealed class PageStreamer<TResource, TRequest, TResponse, TToken>
         where TToken : IEquatable<TToken>
     {
         private readonly Func<TRequest, TToken, TRequest> _requestProvider;
@@ -47,7 +47,7 @@ namespace Google.Apis.Common
         /// <param name="resourceExtractor">Function to extract a sequence of resources from a response.
         /// Must not be null.</param>
         /// <param name="emptyToken">The token to use to detect when there are no more pages available.</param>
-        public Paginator(
+        public PageStreamer(
             Func<TRequest, TToken, TRequest> requestProvider,
             Func<TResponse, TToken> tokenExtractor,
             Func<TResponse, IEnumerable<TResource>> resourceExtractor,
@@ -98,7 +98,7 @@ namespace Google.Apis.Common
             Preconditions.CheckNotNull(responseFetcher, nameof(responseFetcher));
             TRequest nextRequest = initialRequest;
             bool done = false;
-            return new PagingAsyncEnumerable<TResource>(async cancellationToken =>
+            return new PageStreamingAsyncEnumerable<TResource>(async cancellationToken =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (done)

--- a/Google.Apis.Common/src/Google.Apis.Common/PageStreamingAsyncEnumerable.cs
+++ b/Google.Apis.Common/src/Google.Apis.Common/PageStreamingAsyncEnumerable.cs
@@ -10,13 +10,13 @@ using System.Threading.Tasks;
 namespace Google.Apis.Common
 {
     /// <summary>
-    /// Implementation of <see cref="IAsyncEnumerable{T}"/> used for pagination.
+    /// Implementation of <see cref="IAsyncEnumerable{T}"/> used for page streaming.
     /// </summary>
-    internal sealed class PagingAsyncEnumerable<T> : IAsyncEnumerable<T>
+    internal sealed class PageStreamingAsyncEnumerable<T> : IAsyncEnumerable<T>
     {
         private readonly Func<CancellationToken, Task<IEnumerable<T>>> _provider;
 
-        internal PagingAsyncEnumerable(Func<CancellationToken, Task<IEnumerable<T>>> provider)
+        internal PageStreamingAsyncEnumerable(Func<CancellationToken, Task<IEnumerable<T>>> provider)
         {
             _provider = provider;
         }

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.ListBuckets.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.ListBuckets.cs
@@ -14,8 +14,8 @@ namespace Google.Apis.Storage.v1.ClientWrapper
     // ListBuckets methods on StorageClient
     public partial class StorageClient
     {
-        private static readonly Paginator<Bucket, BucketsResource.ListRequest, Buckets, string> s_bucketPaginator =
-            new Paginator<Bucket, BucketsResource.ListRequest, Buckets, string>(
+        private static readonly PageStreamer<Bucket, BucketsResource.ListRequest, Buckets, string> s_bucketPageStreamer =
+            new PageStreamer<Bucket, BucketsResource.ListRequest, Buckets, string>(
                 (request, token) => { request.PageToken = token; return request; },
                 buckets => buckets.NextPageToken,
                 buckets => buckets.Items ?? Enumerable.Empty<Bucket>(),
@@ -55,7 +55,7 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         {
             Preconditions.CheckNotNull(project, nameof(project));
             var initialRequest = CreateListBucketsRequest(project, options);
-            return s_bucketPaginator.FetchAsync(initialRequest, (req, cancellationToken) => req.ExecuteAsync(cancellationToken));
+            return s_bucketPageStreamer.FetchAsync(initialRequest, (req, cancellationToken) => req.ExecuteAsync(cancellationToken));
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         {
             Preconditions.CheckNotNull(project, nameof(project));
             var initialRequest = CreateListBucketsRequest(project, options);
-            return s_bucketPaginator.Fetch(initialRequest, req => req.Execute());
+            return s_bucketPageStreamer.Fetch(initialRequest, req => req.Execute());
         }
 
         private BucketsResource.ListRequest CreateListBucketsRequest(string project, ListBucketsOptions options)

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.ListObjects.cs
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/StorageClient.ListObjects.cs
@@ -15,8 +15,8 @@ namespace Google.Apis.Storage.v1.ClientWrapper
     // ListObjects methods on StorageClient
     public partial class StorageClient
     {
-        private static readonly Paginator<Object, ObjectsResource.ListRequest, Objects, string> s_objectPaginator =
-            new Paginator<Object, ObjectsResource.ListRequest, Objects, string>(
+        private static readonly PageStreamer<Object, ObjectsResource.ListRequest, Objects, string> s_objectPageStreamer =
+            new PageStreamer<Object, ObjectsResource.ListRequest, Objects, string>(
                 (request, token) => { request.PageToken = token; return request; },
                 objects => objects.NextPageToken,
                 objects => objects.Items ?? Enumerable.Empty<Object>(),
@@ -60,7 +60,7 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         public IAsyncEnumerable<Object> ListObjectsAsync(string bucket, string prefix, ListObjectsOptions options = null)
         {
             var initialRequest = CreateListObjectsRequest(bucket, prefix, options);
-            return s_objectPaginator.FetchAsync(initialRequest, (req, cancellationToken) => req.ExecuteAsync(cancellationToken));
+            return s_objectPageStreamer.FetchAsync(initialRequest, (req, cancellationToken) => req.ExecuteAsync(cancellationToken));
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Google.Apis.Storage.v1.ClientWrapper
         public IEnumerable<Object> ListObjects(string bucket, string prefix, ListObjectsOptions options = null)
         {
             var initialRequest = CreateListObjectsRequest(bucket, prefix, options);
-            return s_objectPaginator.Fetch(initialRequest, req => req.Execute());
+            return s_objectPageStreamer.Fetch(initialRequest, req => req.Execute());
         }
 
         private ObjectsResource.ListRequest CreateListObjectsRequest(string bucket, string prefix, ListObjectsOptions options)


### PR DESCRIPTION
(A Paginator would more reasonably break a stream of items into pages; this does the opposite.)