### PR TITLE
Update version numbers to include the alpha tag, and start at 0.1

### DIFF
--- a/Google.Apis.Common/src/Google.Apis.Common/project.json
+++ b/Google.Apis.Common/src/Google.Apis.Common/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.0.0-*",
+  "version": "0.1.0-alpha-*",
   "description": "Support classes for API client libraries",
   "authors": [ "Google" ],
   "tags": [ "" ],
@@ -7,7 +7,10 @@
   "licenseUrl": "",
 
   "dependencies": {
-    "Google.Common.Embeddable": { "type": "build", "version": "0.0.0-*" },
+    "Google.Common.Embeddable": {
+      "type": "build",
+      "version": "0.1.0-alpha-*"
+    },
     "Ix-Async": "1.2.5"
   },
 

--- a/Google.Common/src/Google.Common.Embeddable/project.json
+++ b/Google.Common/src/Google.Common.Embeddable/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.0.0-*",
+  "version": "0.1.0-alpha-*",
   "description": "Embeddable library of commonly-used code",
   "authors": [ "Google" ],
   "tags": [ "" ],

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/project.json
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.ClientWrapper/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.0.0-*",
+  "version": "0.1.0-alpha-*",
   "description": "Wrapper library for Google.Apis.Storage.v1",
   "authors": [ "googleapis-packages" ],
   "tags": [ "" ],
@@ -11,9 +11,9 @@
     "Google.Apis.Storage.v1": "1.10.0.550",
     "Google.Common.Embeddable": {
       "type": "build",
-      "version": "0.0.0-*"
+      "version": "0.1.0-alpha-*"
     },
-    "Google.Apis.Common": "0.0.0-*",
+    "Google.Apis.Common": "0.1.0-alpha-*",
     "Google.Apis.Core": "1.10.0",
     "Ix-Async": "1.2.5"
   },

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.Demo/project.json
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.Demo/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.0.0-*",
+  "version": "0.1.0-alpha-*",
   "description": "Console application to demonstrate (and test) the client wrapper library",
   "authors": [ "googleapis-packages" ],
   "tags": [ "" ],
@@ -9,7 +9,7 @@
   "dependencies": {
     "Google.Apis.Auth": "1.10.0",
     "Google.Apis.Storage.v1": "1.10.0.550",
-    "Google.Apis.Storage.v1.ClientWrapper": "0.0.0-*",
+    "Google.Apis.Storage.v1.ClientWrapper": "0.1.0-alpha-*",
     "Microsoft.Framework.CommandLineUtils.Sources": {
       "version": "1.0.0-*",
       "type": "build"

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/project.json
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.0.0-*",
+  "version": "0.1.0-alpha-*",
   "description": "Integration tests for the Cloud Storage client wrapper library",
   "authors": [ "googleapis-packages" ],
   "tags": [ "" ],
@@ -7,7 +7,7 @@
   "licenseUrl": "",
 
   "dependencies": {
-    "Google.Apis.Storage.v1.ClientWrapper": "0.0.0-*",
+    "Google.Apis.Storage.v1.ClientWrapper": "0.1.0-alpha-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/project.json
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.Tests/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.0.0-*",
+  "version": "0.1.0-alpha-*",
   "description": "Unit tests for the Cloud Storage client wrapper library",
   "authors": [ "googleapis-packages" ],
   "tags": [ "" ],
@@ -7,7 +7,7 @@
   "licenseUrl": "",
 
   "dependencies": {
-    "Google.Apis.Storage.v1.ClientWrapper": "0.0.0-*",
+    "Google.Apis.Storage.v1.ClientWrapper": "0.1.0-alpha-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },


### PR DESCRIPTION
I suspect we need to examine all of this more carefully before release, but it produces valid nuget packages.