### PR TITLE
Add a readme file to otherwise-empty test data directories

### DIFF
--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-2/readme.txt
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-2/readme.txt
@@ -1,0 +1,5 @@
+This is just a sample file to persuade git to include
+the otherwise-empty directory.
+
+It doesn't interfere with tests, but should be removed
+if a test starts including actual data in this directory.

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-3/readme.txt
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-3/readme.txt
@@ -1,0 +1,5 @@
+This is just a sample file to persuade git to include
+the otherwise-empty directory.
+
+It doesn't interfere with tests, but should be removed
+if a test starts including actual data in this directory.

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-4/readme.txt
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-4/readme.txt
@@ -1,0 +1,5 @@
+This is just a sample file to persuade git to include
+the otherwise-empty directory.
+
+It doesn't interfere with tests, but should be removed
+if a test starts including actual data in this directory.

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-5/readme.txt
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-5/readme.txt
@@ -1,0 +1,5 @@
+This is just a sample file to persuade git to include
+the otherwise-empty directory.
+
+It doesn't interfere with tests, but should be removed
+if a test starts including actual data in this directory.

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-6/readme.txt
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-6/readme.txt
@@ -1,0 +1,5 @@
+This is just a sample file to persuade git to include
+the otherwise-empty directory.
+
+It doesn't interfere with tests, but should be removed
+if a test starts including actual data in this directory.

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-7/readme.txt
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-7/readme.txt
@@ -1,0 +1,5 @@
+This is just a sample file to persuade git to include
+the otherwise-empty directory.
+
+It doesn't interfere with tests, but should be removed
+if a test starts including actual data in this directory.

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-8/readme.txt
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-8/readme.txt
@@ -1,0 +1,5 @@
+This is just a sample file to persuade git to include
+the otherwise-empty directory.
+
+It doesn't interfere with tests, but should be removed
+if a test starts including actual data in this directory.

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-9/readme.txt
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-9/readme.txt
@@ -1,0 +1,5 @@
+This is just a sample file to persuade git to include
+the otherwise-empty directory.
+
+It doesn't interfere with tests, but should be removed
+if a test starts including actual data in this directory.

--- a/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-extra/readme.txt
+++ b/GoogleApiWrappers/src/Google.Apis.Storage.v1.IntegrationTests/data/integrationtests-extra/readme.txt
@@ -1,0 +1,5 @@
+This is just a sample file to persuade git to include
+the otherwise-empty directory.
+
+It doesn't interfere with tests, but should be removed
+if a test starts including actual data in this directory.


### PR DESCRIPTION
Git doesn't track empty directories, which would mean anyone just checking out
the repository and running setup.bat would get failures.