### PR TITLE
First pass at a myget build

### DIFF
--- a/Google.Apis.Common/src/Google.Apis.Common/project.json
+++ b/Google.Apis.Common/src/Google.Apis.Common/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.1.0-alpha-*",
+  "version": "0.1.0-*",
   "description": "Support classes for API client libraries",
   "authors": [ "Google" ],
   "tags": [ "" ],

--- a/myget.bat
+++ b/myget.bat
@@ -1,0 +1,25 @@
+REM This is all ugly... we'll want to revisit this as soon as possible
+call dnvm use 1.0.0-rc1-update1 -r clr
+
+REM Temporary measure while we resolve oddities with the local feed
+REM cache and version numbers. Basically, we want to fetch these from
+REM nuget.org.
+rmdir /s /q %USERPROFILE%\.dnx\packages\Google.Apis
+rmdir /s /q %USERPROFILE%\.dnx\packages\Google.Apis.Core
+rmdir /s /q %USERPROFILE%\.dnx\packages\Google.Apis.Auth
+
+call dnu restore
+IF ERRORLEVEL 1 EXIT /B 1
+
+call dnu build src\Google.Storage.V1
+IF ERRORLEVEL 1 EXIT /B 1
+call dnu build test\Google.Storage.V1.Tests
+IF ERRORLEVEL 1 EXIT /B 1
+call dnu build test\Google.Storage.V1.IntegrationTests
+IF ERRORLEVEL 1 EXIT /B 1
+call dnu build demo\Google.Storage.V1.Demo
+IF ERRORLEVEL 1 EXIT /B 1
+call dnx -p test\Google.Storage.V1.Tests test
+IF ERRORLEVEL 1 EXIT /B 1
+call dnu pack src\Google.Storage.V1
+IF ERRORLEVEL 1 EXIT /B 1

--- a/pre-myget.bat
+++ b/pre-myget.bat
@@ -1,0 +1,2 @@
+call dnvm install 1.0.0-rc1-update1 -r clr
+

--- a/src/Google.Storage.V1/project.json
+++ b/src/Google.Storage.V1/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.1.0-alpha-*",
+  "version": "0.1.0-*",
   "summary": "Wrapper library for Google.Apis.Storage.v1",
   "description": "Wrapper library for Google.Apis.Storage.v1, making common operations simpler in client code.",
   "authors": [ "Google Inc." ],


### PR DESCRIPTION
Batchfiles (as per gax-dotnet) until we've got something better.
(It's a shame myget doesn't appear to support shell scripts - only .cmd, .bat and .ps1.)

Deleting the .dnx\packages\google.{...} directories is currently required due to some version discrepancies - hopefully this will be short-lived.