### PR TITLE
First steps to generate API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 obj
 bin
 project.lock.json
+_site

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,31 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [ "src/*/project.json" ],
+          "exclude": [ "**/bin/**", "**/obj/**" ],
+          "cwd": ""
+        }
+      ],
+      "dest": "obj/api"
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [ "**/*.yml" ],
+        "cwd": "obj/api",
+        "dest": "api"
+      },
+      {
+        "files": [ "*.md", "toc.yml" ],
+        "cwd": "docs"
+      }
+    ],
+    "globalMetadata": {
+      "_appTitle": "Google Cloud APIs"
+    },
+    "dest": "_site"
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,37 @@
+# Introduction
+
+This is preliminary documentation for the Google Cloud APIs
+repository.
+
+## Google.Storage.V1
+
+A wrapper library over
+[Google.Apis.Storage.v1](https://www.nuget.org/packages/Google.Apis.Storage.v1/)
+for working with [Google Cloud Storage](https://cloud.google.com/storage/)
+
+Common operations are exposed via the
+[`StorageClient`](../obj/api/Google.Storage.V1.StorageClient.yml) class.
+
+## Google.Pubsub.V1
+
+A library for working with [Google Cloud Pub/sub](https://cloud.google.com/pubsub/).
+
+The API operates at three abstractions:
+
+- `SimplePubsub` (coming soon) is a simplified API making common
+scenarios extremely straightforward.
+- [`PublisherClient`](../obj/api/Google.Pubsub.V1.PublisherClient.yml) and
+[`SubscriberClient`](../obj/api/Google.Pubsub.V1.SubscriberClient.yml)
+provide a general-purpose abstraction over raw the RPC API, providing
+features such as page streaming to make client code cleaner and
+simpler.
+- [`IPublisherClient`](../obj/api/Google.Pubsub.V1.Publisher.IPublisherClient.yml)
+and [`ISubscriberClient`](../obj/api/Google.Pubsub.V1.Subscriber.ISubscriberClient.yml)
+expose the raw RPC API. Most clients will never need to use this
+abstraction, but it provides the most flexibility for via specific
+scenarios.
+
+Each abstraction is built over the lower-level one, and client code
+can mix and match abstractions very easily: you may be able to use
+`SimplePubsub` for most of your code, dropping down to
+`PublisherClient` and `SubscriberClient` occasionally, for example.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,4 @@
+- name: Home
+  href: index.md
+- name: API Documentation
+  href: ../obj/api/

--- a/src/Google.Pubsub.V1/PublisherClient.cs
+++ b/src/Google.Pubsub.V1/PublisherClient.cs
@@ -40,7 +40,7 @@ namespace Google.Pubsub.V1
     public sealed partial class PublisherSettings : ServiceSettingsBase<PublisherSettings>
     {
         /// <summary>
-        /// Get a new instance of the default <see cref="PublisherSettings">.
+        /// Get a new instance of the default <see cref="PublisherSettings"/>.
         /// </summary>
         /// <returns>A new instance of the default PublisherSettings.</returns>
         public static PublisherSettings GetDefault() => new PublisherSettings();

--- a/src/Google.Pubsub.V1/SubscriberClient.cs
+++ b/src/Google.Pubsub.V1/SubscriberClient.cs
@@ -42,7 +42,7 @@ namespace Google.Pubsub.V1
     public sealed partial class SubscriberSettings : ServiceSettingsBase<SubscriberSettings>
     {
         /// <summary>
-        /// Get a new instance of the default <see cref="PublisherSettings">.
+        /// Get a new instance of the default <see cref="PublisherSettings"/>.
         /// </summary>
         /// <returns>A new instance of the default SubscriberSettings.</returns>
         public static SubscriberSettings GetDefault() => new SubscriberSettings();

--- a/src/Google.Storage.V1/StorageClient.GetObject.cs
+++ b/src/Google.Storage.V1/StorageClient.GetObject.cs
@@ -13,7 +13,7 @@ namespace Google.Storage.V1
         /// <summary>
         /// Fetches the information about an object synchronously.
         /// </summary>
-        /// <remarks>This does not retrieve the content of the object itself. Use <see cref="DownloadObject(string, string,  System.IO.Stream)"/>
+        /// <remarks>This does not retrieve the content of the object itself. Use <see cref="DownloadObject(string, string, System.IO.Stream, DownloadObjectOptions, System.IProgress{Apis.Download.IDownloadProgress})"/>
         /// to download the content.</remarks>
         /// <param name="bucket">The name of the bucket containing the object. Must not be null.</param>
         /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
@@ -30,7 +30,7 @@ namespace Google.Storage.V1
         /// <summary>
         /// Fetches the information about an object asynchronously.
         /// </summary>
-        /// <remarks>This does not retrieve the content of the object itself. Use <see cref="DownloadObject(string, string, System.IO.Stream)"/>
+        /// <remarks>This does not retrieve the content of the object itself. Use <see cref="DownloadObjectAsync(string, string, System.IO.Stream, DownloadObjectOptions, CancellationToken, System.IProgress{Apis.Download.IDownloadProgress})"/>
         /// to download the content.</remarks>
         /// <param name="bucket">The name of the bucket containing the object. Must not be null.</param>
         /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>


### PR DESCRIPTION
See http://jskeet.github.io/gcloud-dotnet/ for an example of how it will look. We can
fiddle with templates etc later, of course.