### PR TITLE
Simplify client creation

### DIFF
--- a/demo/Google.Pubsub.V1.Demo/Program.cs
+++ b/demo/Google.Pubsub.V1.Demo/Program.cs
@@ -80,12 +80,12 @@ namespace Google.Pubsub.V1.Demo
         /// </summary>
         private static void ConfigureForExecution(CommandLineApplication config, Func<PublisherClient, Task> command)
         {
-            ConfigureForExecution(config, () => PublisherClient.CreateFromDefaultCredentialsAsync(), command);
+            ConfigureForExecution(config, () => PublisherClient.CreateAsync(), command);
         }
 
         private static void ConfigureForExecution(CommandLineApplication config, Func<SubscriberClient, Task> command)
         {
-            ConfigureForExecution(config, () => SubscriberClient.CreateFromDefaultCredentialsAsync(), command);
+            ConfigureForExecution(config, () => SubscriberClient.CreateAsync(), command);
         }
 
         private static void ConfigureForExecution<TClient>(CommandLineApplication config, Func<Task<TClient>> clientProvider, Func<TClient, Task> command)

--- a/src/Google.Pubsub.V1/PublisherClient.cs
+++ b/src/Google.Pubsub.V1/PublisherClient.cs
@@ -4,6 +4,7 @@
 // Generated code. DO NOT EDIT!
 
 using Google.Api.Gax;
+using Google.Apis.Auth.OAuth2;
 using Grpc.Core;
 using System;
 using System.Collections.Generic;
@@ -60,41 +61,24 @@ namespace Google.Pubsub.V1
     public abstract partial class PublisherClient
     {
         /// <summary>
-        /// Default service parameters for the Publisher service.
+        /// The default endpoint for the service, which is a host of "pubsub-experimental.googleapis.com" and a port of 443.
         /// </summary>
-        public static class ServiceDefaults
-        {
-            /// <summary>
-            /// The default Publisher network host.
-            /// </summary>
-            /// <remarks>
-            /// The default Publisher network host is "pubsub-experimental.googleapis.com".
-            /// </remarks>
-            public static string Host { get; } = "pubsub-experimental.googleapis.com";
+        public static ServiceEndpoint DefaultEndpoint { get; } = new ServiceEndpoint("pubsub-experimental.googleapis.com", 443);
 
-            /// <summary>
-            /// The default Publisher network port.
-            /// </summary>
-            /// <remarks>
-            /// The default Publisher network port is 443.
-            /// </remarks>
-            public static int Port { get; } = 443;
-
-            /// <summary>
-            /// The default Publisher scopes
-            /// </summary>
-            /// <remarks>
-            /// The default Publisher scopes are:
-            /// <list type="bullet">
-            /// <item><description>"https://www.googleapis.com/auth/pubsub"</description></item>
-            /// <item><description>"https://www.googleapis.com/auth/cloud-platform"</description></item>
-            /// </list>
-            /// </remarks>
-            public static IReadOnlyList<string> Scopes { get; } = new ReadOnlyCollection<string>(new[] {
-                "https://www.googleapis.com/auth/pubsub",
-                "https://www.googleapis.com/auth/cloud-platform",
-            });
-        }
+        /// <summary>
+        /// The default Publisher scopes
+        /// </summary>
+        /// <remarks>
+        /// The default Publisher scopes are:
+        /// <list type="bullet">
+        /// <item><description>"https://www.googleapis.com/auth/pubsub"</description></item>
+        /// <item><description>"https://www.googleapis.com/auth/cloud-platform"</description></item>
+        /// </list>
+        /// </remarks>
+        public static IReadOnlyList<string> DefaultScopes { get; } = new ReadOnlyCollection<string>(new[] {
+            "https://www.googleapis.com/auth/pubsub",
+            "https://www.googleapis.com/auth/cloud-platform",
+        });
 
         /// <summary>
         /// Path template for a project resource. Parameters:
@@ -128,74 +112,47 @@ namespace Google.Pubsub.V1
         /// <returns>The full topic resource name.</returns>
         public static string GetTopicName(string projectId, string topicId) => TopicTemplate.Expand(projectId, topicId);
 
+        // Note: we could have parameterless overloads of Create and CreateAsync,
+        // documented to just use the default endpoint, settings and credentials.
+        // Pros: 
+        // - Might be more reassuring on first use
+        // - Allows method group conversions
+        // Con: overloads!
 
         /// <summary>
-        /// Get a new instance of the default <see cref="ServiceEndpointSettings"/>.
+        /// Asynchronously creates a <see cref="PublisherClient"/>, applying defaults for all unspecified settings.
         /// </summary>
-        /// <remarks>
-        /// The default service endpoint settings are:
-        /// <list type="bullet">
-        /// <item><description>Host "pubsub-experimental.googleapis.com"</description></item>
-        /// <item><description>Port 443</description></item>
-        /// </list>
-        /// </remarks>
-        public static ServiceEndpointSettings GetDefaultServiceEndpointSettings() => new ServiceEndpointSettings
-        {
-            Host = ServiceDefaults.Host,
-            Port = ServiceDefaults.Port,
-        };
-
-        /// <summary>
-        /// Asynchronously create a <see cref="PublisherClient"/> from default credentials.
-        /// </summary>
+        /// <param name="endpoint">Optional <see cref="ServiceEndpoint"/>.</param>
         /// <param name="settings">Optional <see cref="PublisherSettings"/>.</param>
-        /// <param name="serviceEndpointSettings">Optional <see cref="ServiceEndpointSettings"/>.</param>
-        /// <param name="credentialScopes">Optional scopes for default credentials.</param>
-        /// <returns>A newly created <see cref="PublisherClient"/>.</returns>
-        public static Task<PublisherClient> CreateFromDefaultCredentialsAsync(
-            PublisherSettings settings = null,
-            ServiceEndpointSettings serviceEndpointSettings = null,
-            IEnumerable<string> credentialScopes = null)
-        {
-            return ClientHelper.CreateFromDefaultCredentialsAsync(
-                settings, serviceEndpointSettings, credentialScopes, ServiceDefaults.Scopes, CreateFromCredentials);
-        }
-
-        /// <summary>
-        /// Create a <see cref="PublisherClient"/> from default credentials.
-        /// </summary>
-        /// <param name="settings">Optional <see cref="PublisherSettings"/>.</param>
-        /// <param name="serviceEndpointSettings">Optional <see cref="ServiceEndpointSettings"/>.</param>
-        /// <param name="credentialScopes">Optional scopes for default credentials.</param>
-        /// <returns>A newly created <see cref="PublisherClient"/>.</returns>
-        public static PublisherClient CreateFromDefaultCredentials(
-            PublisherSettings settings = null,
-            ServiceEndpointSettings serviceEndpointSettings = null,
-            IEnumerable<string> credentialScopes = null)
-        {
-            return ClientHelper.CreateFromDefaultCredentials(
-                settings, serviceEndpointSettings, credentialScopes, ServiceDefaults.Scopes, CreateFromCredentials);
-        }
-
-        /// <summary>
-        /// Create a <see cref="PublisherClient"/> from the specified credentials.
-        /// </summary>
-        /// <param name="credentials">The credentials with which to configure the GRPC channel.</param>
-        /// <param name="settings">Optional <see cref="PublisherSettings"/>.</param>
-        /// <param name="serviceEndpointSettings">Optional <see cref="ServiceEndpointSettings"/>.</param>
+        /// <param name="credentials">Optional <see cref="ChannelCredentials"/>.</param>
         /// <returns></returns>
-        public static PublisherClient CreateFromCredentials(
-            ChannelCredentials credentials,
+        public static async Task<PublisherClient> CreateAsync(
+            ServiceEndpoint endpoint = null,
             PublisherSettings settings = null,
-            ServiceEndpointSettings serviceEndpointSettings = null)
+            ChannelCredentials credentials = null)
         {
-            Channel channel = ClientHelper.CreateChannel(
-                serviceEndpointSettings ?? GetDefaultServiceEndpointSettings(),
-                ServiceDefaults.Host, ServiceDefaults.Port, credentials);
-            Publisher.IPublisherClient grpcClient = new Publisher.PublisherClient(channel);
+            var channel = await ClientHelper.CreateChannelAsync(endpoint ?? DefaultEndpoint, credentials).ConfigureAwait(false);
+            var grpcClient = new Publisher.PublisherClient(channel);
             return new PublisherClientImpl(grpcClient, settings);
         }
 
+        /// <summary>
+        /// Synchronously creates a <see cref="PublisherClient"/>, applying defaults for all unspecified settings.
+        /// </summary>
+        /// <param name="endpoint">Optional <see cref="ServiceEndpoint"/>.</param>
+        /// <param name="settings">Optional <see cref="PublisherSettings"/>.</param>
+        /// <param name="credentials">Optional <see cref="ChannelCredentials"/>.</param>
+        /// <returns></returns>
+        public static PublisherClient Create(
+            ServiceEndpoint endpoint = null,
+            PublisherSettings settings = null,
+            ChannelCredentials credentials = null)
+        {
+            var channel = ClientHelper.CreateChannel(endpoint ?? DefaultEndpoint, credentials);
+            var grpcClient = new Publisher.PublisherClient(channel);
+            return new PublisherClientImpl(grpcClient, settings);
+        }
+        
         /// <summary>
         /// The underlying GRPC Publisher client.
         /// </summary>

--- a/src/Google.Pubsub.V1/SubscriberClient.cs
+++ b/src/Google.Pubsub.V1/SubscriberClient.cs
@@ -60,42 +60,25 @@ namespace Google.Pubsub.V1
     public abstract partial class SubscriberClient
     {
         /// <summary>
-        /// Default service parameters for the Subscriber service.
+        /// The default endpoint for the service, which is a host of "pubsub-experimental.googleapis.com" and a port of 443.
         /// </summary>
-        public static class ServiceDefaults
-        {
-            /// <summary>
-            /// The default Subscriber network host.
-            /// </summary>
-            /// <remarks>
-            /// The default Subscriber network host is "pubsub-experimental.googleapis.com".
-            /// </remarks>
-            public static string Host { get; } = "pubsub-experimental.googleapis.com";
+        public static ServiceEndpoint DefaultEndpoint { get; } = new ServiceEndpoint("pubsub-experimental.googleapis.com", 443);
 
-            /// <summary>
-            /// The default Subscriber network port.
-            /// </summary>
-            /// <remarks>
-            /// The default Subscriber network port is 443.
-            /// </remarks>
-            public static int Port { get; } = 443;
-
-            /// <summary>
-            /// The default Subscriber scopes
-            /// </summary>
-            /// <remarks>
-            /// The default Subscriber scopes are:
-            /// <list type="bullet">
-            /// <item><description>"https://www.googleapis.com/auth/pubsub"</description></item>
-            /// <item><description>"https://www.googleapis.com/auth/cloud-platform"</description></item>
-            /// </list>
-            /// </remarks>
-            public static IReadOnlyList<string> Scopes { get; } = new ReadOnlyCollection<string>(new[] {
+        /// <summary>
+        /// The default Subscriber scopes
+        /// </summary>
+        /// <remarks>
+        /// The default Subscriber scopes are:
+        /// <list type="bullet">
+        /// <item><description>"https://www.googleapis.com/auth/pubsub"</description></item>
+        /// <item><description>"https://www.googleapis.com/auth/cloud-platform"</description></item>
+        /// </list>
+        /// </remarks>
+        public static IReadOnlyList<string> Scopes { get; } = new ReadOnlyCollection<string>(new[] {
                 "https://www.googleapis.com/auth/pubsub",
                 "https://www.googleapis.com/auth/cloud-platform",
             });
-        }
-
+        
         /// <summary>
         /// Path template for a project resource. Parameters:
         /// <list type="bullet">
@@ -128,73 +111,39 @@ namespace Google.Pubsub.V1
         /// <returns>The full subscription resource name.</returns>
         public static string GetSubscriptionName(string projectId, string subscriptionId) => SubscriptionTemplate.Expand(projectId, subscriptionId);
 
-
         /// <summary>
-        /// Get a new instance of the default <see cref="ServiceEndpointSettings"/>.
+        /// Asynchronously creates a <see cref="SubscriberClient"/>, applying defaults for all unspecified settings.
         /// </summary>
-        /// <remarks>
-        /// The default service endpoint settings are:
-        /// <list type="bullet">
-        /// <item><description>Host "pubsub-experimental.googleapis.com"</description></item>
-        /// <item><description>Port 443</description></item>
-        /// </list>
-        /// </remarks>
-        public static ServiceEndpointSettings GetDefaultServiceEndpointSettings() => new ServiceEndpointSettings
-        {
-            Host = ServiceDefaults.Host,
-            Port = ServiceDefaults.Port,
-        };
-
-        /// <summary>
-        /// Asynchronously create a <see cref="SubscriberClient"/> from default credentials.
-        /// </summary>
-        /// <param name="settings">Optional <see cref="SubscriberSettings"/>.</param>
-        /// <param name="serviceEndpointSettings">Optional <see cref="ServiceEndpointSettings"/>.</param>
-        /// <param name="credentialScopes">Optional scopes for default credentials.</param>
-        /// <returns>A newly created <see cref="SubscriberClient"/>.</returns>
-        public static Task<SubscriberClient> CreateFromDefaultCredentialsAsync(
-            SubscriberSettings settings = null,
-            ServiceEndpointSettings serviceEndpointSettings = null,
-            IEnumerable<string> credentialScopes = null)
-        {
-            return ClientHelper.CreateFromDefaultCredentialsAsync(
-                settings, serviceEndpointSettings, credentialScopes, ServiceDefaults.Scopes, CreateFromCredentials);
-        }
-
-        /// <summary>
-        /// Create a <see cref="SubscriberClient"/> from default credentials.
-        /// </summary>
-        /// <param name="settings">Optional <see cref="SubscriberSettings"/>.</param>
-        /// <param name="serviceEndpointSettings">Optional <see cref="ServiceEndpointSettings"/>.</param>
-        /// <param name="credentialScopes">Optional scopes for default credentials.</param>
-        /// <returns>A newly created <see cref="SubscriberClient"/>.</returns>
-        public static SubscriberClient CreateFromDefaultCredentials(
-            SubscriberSettings settings = null,
-            ServiceEndpointSettings serviceEndpointSettings = null,
-            IEnumerable<string> credentialScopes = null)
-        {
-            return ClientHelper.CreateFromDefaultCredentials(
-                settings, serviceEndpointSettings, credentialScopes, ServiceDefaults.Scopes, CreateFromCredentials);
-        }
-
-        /// <summary>
-        /// Create a <see cref="SubscriberClient"/> from the specified credentials.
-        /// </summary>
-        /// <param name="credentials">The credentials with which to configure the GRPC channel.</param>
-        /// <param name="settings">Optional <see cref="SubscriberSettings"/>.</param>
-        /// <param name="serviceEndpointSettings">Optional <see cref="ServiceEndpointSettings"/>.</param>
+        /// <param name="endpoint">Optional <see cref="ServiceEndpoint"/>.</param>
+        /// <param name="settings">Optional <see cref="PublisherSettings"/>.</param>
+        /// <param name="credentials">Optional <see cref="ChannelCredentials"/>.</param>
         /// <returns></returns>
-        public static SubscriberClient CreateFromCredentials(
-            ChannelCredentials credentials,
+        public static async Task<SubscriberClient> CreateAsync(
+            ServiceEndpoint endpoint = null,
             SubscriberSettings settings = null,
-            ServiceEndpointSettings serviceEndpointSettings = null)
+            ChannelCredentials credentials = null)
         {
-            Channel channel = ClientHelper.CreateChannel(
-                serviceEndpointSettings ?? GetDefaultServiceEndpointSettings(),
-                ServiceDefaults.Host, ServiceDefaults.Port, credentials);
-            Subscriber.ISubscriberClient grpcClient = new Subscriber.SubscriberClient(channel);
+            var channel = await ClientHelper.CreateChannelAsync(endpoint ?? DefaultEndpoint, credentials).ConfigureAwait(false);
+            var grpcClient = new Subscriber.SubscriberClient(channel);
             return new SubscriberClientImpl(grpcClient, settings);
         }
+
+        /// <summary>
+        /// Synchronously creates a <see cref="SubscriberClient"/>, applying defaults for all unspecified settings.
+        /// </summary>
+        /// <param name="endpoint">Optional <see cref="ServiceEndpoint"/>.</param>
+        /// <param name="settings">Optional <see cref="PublisherSettings"/>.</param>
+        /// <param name="credentials">Optional <see cref="ChannelCredentials"/>.</param>
+        /// <returns></returns>
+        public static SubscriberClient Create(
+            ServiceEndpoint endpoint = null,
+            SubscriberSettings settings = null,
+            ChannelCredentials credentials = null)
+        {
+            var channel = ClientHelper.CreateChannel(endpoint ?? DefaultEndpoint, credentials);
+            var grpcClient = new Subscriber.SubscriberClient(channel);
+            return new SubscriberClientImpl(grpcClient, settings);
+        }        
 
         /// <summary>
         /// The underlying GRPC Subscriber client.

--- a/src/Google.Pubsub.V1/project.json
+++ b/src/Google.Pubsub.V1/project.json
@@ -14,7 +14,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax": "0.1.0-CI00029",
+    "Google.Api.Gax": "0.1.0-CI00030",
     "Google.Apis.Auth": "1.10.0",
     "Google.Protobuf": "3.0.0-beta2",
     "Grpc.Auth": "0.13.0",


### PR DESCRIPTION
Important points:
- Shorter, friendlier names for creation methods
- Don't allow scopes to be specified separately - if you want your own scopes, create your own credentials
- ServiceEndPoint as a new immutable class. There is precedence for *some* immutability in the BCL, e.g. IPEndPoint :)
- With only two members, the ServiceDefaults nested class becomes a bit pointless

// cc @jgeewax who suggested this
// cc @csells who likes mutability in general, but who I suspect will be okay with ServiceEndPoint
// cc @mmdriley and @ivannaranjo as general good feedback providers :)