### PR TITLE
Update storage dependencies

### DIFF
--- a/demo/Google.Storage.V1.Demo/project.json
+++ b/demo/Google.Storage.V1.Demo/project.json
@@ -2,8 +2,7 @@
   "description": "Console application to demonstrate (and test) the client wrapper library",
 
   "dependencies": {
-    "Google.Apis.Auth": "1.11.0",
-    "Google.Apis.Storage.v1": "1.10.0.550",
+    "Google.Apis.Storage.v1": "1.12.0.448",
     "Google.Storage.V1": "",
     "Microsoft.Framework.CommandLineUtils.Sources": {
       "version": "1.0.0-*",

--- a/src/Google.Storage.V1/project.json
+++ b/src/Google.Storage.V1/project.json
@@ -15,13 +15,21 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax": "0.1.0-CI00029",
-    "Google.Apis": "1.11.0",
-    "Google.Apis.Auth": "1.11.0",
-    "Google.Apis.Core": "1.11.0",
-    "Google.Apis.Storage.v1": "1.10.0.550"
+    "Google.Apis": "1.11.1",
+    "Google.Apis.Auth": "1.11.1",
+    "Google.Apis.Core": "1.11.1",
+    "Google.Apis.Storage.v1": "1.12.0.448"
   },
   "frameworks": {
-    "net451": { }
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Runtime": {
+          "type": "build"
+        },
+        "System.IO": {
+          "type": "build"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
- Remove dependency on Google.Api.Gax, which wasn't needed (and brought in lots of other stuff for no reason)
- Update dependencies on underlying APIs
- Add framework dependencies on System.Runtime and System.IO, but specify them as type=build to avoid issues with .NET 4.6+