### PR TITLE
Update GAX dependency in all APIs

### DIFF
--- a/src/Google.Logging.Type/project.json
+++ b/src/Google.Logging.Type/project.json
@@ -14,7 +14,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax": "0.1.0-CI00037",
+    "Google.Api.Gax": "0.1.0-CI00038",
     "Google.Protobuf": "3.0.0-beta2"
   },
 

--- a/src/Google.Logging.V2/project.json
+++ b/src/Google.Logging.V2/project.json
@@ -14,7 +14,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax": "0.1.0-CI00037",
+    "Google.Api.Gax": "0.1.0-CI00038",
     "Google.Apis.Auth": "1.11.1",
     "Google.Logging.Type":  "",
     "Google.Protobuf": "3.0.0-beta2",

--- a/src/Google.Pubsub.V1/project.json
+++ b/src/Google.Pubsub.V1/project.json
@@ -14,7 +14,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax": "0.1.0-CI00037",
+    "Google.Api.Gax": "0.1.0-CI00038",
     "Google.Apis.Auth": "1.11.1",
     "Google.Protobuf": "3.0.0-beta2",
     "Grpc.Auth": "0.13.1",


### PR DESCRIPTION
(CI00038 is now on nuget)