### PR TITLE
Aysnc cancellation rationalisation

### DIFF
--- a/src/Google.Pubsub.V1/PublisherClient.cs
+++ b/src/Google.Pubsub.V1/PublisherClient.cs
@@ -182,16 +182,33 @@ namespace Google.Pubsub.V1
         /// signs (`%`). It must be between 3 and 255 characters in length, and it
         /// must not start with `"goog"`.
         /// </param>
-        /// <param name="cancellationToken">If not null, a <see cref="CancellationToken"/> to use for this RPC.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
         public virtual Task<Topic> CreateTopicAsync(
             string name,
-            CancellationToken? cancellationToken = null,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Creates the given topic with the given name.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the topic. It must have the format
+        /// `"projects/{project}/topics/{topic}"`. `{topic}` must start with a letter,
+        /// and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
+        /// underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
+        /// signs (`%`). It must be between 3 and 255 characters in length, and it
+        /// must not start with `"goog"`.
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual Task<Topic> CreateTopicAsync(
+            string name,
+            CancellationToken cancellationToken) => CreateTopicAsync(
+                name,
+                new CallSettings { CancellationToken = cancellationToken });
 
         /// <summary>
         /// Creates the given topic with the given name.
@@ -220,17 +237,32 @@ namespace Google.Pubsub.V1
         /// </summary>
         /// <param name="topic">The messages in the request will be published on this topic.</param>
         /// <param name="messages">The messages to publish.</param>
-        /// <param name="cancellationToken">If not null, a <see cref="CancellationToken"/> to use for this RPC.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
         public virtual Task<PublishResponse> PublishAsync(
             string topic,
             IEnumerable<PubsubMessage> messages,
-            CancellationToken? cancellationToken = null,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Adds one or more messages to the topic. Generates `NOT_FOUND` if the topic
+        /// does not exist. The message payload must not be empty; it must contain
+        ///  either a non-empty data field, or at least one attribute.
+        /// </summary>
+        /// <param name="topic">The messages in the request will be published on this topic.</param>
+        /// <param name="messages">The messages to publish.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual Task<PublishResponse> PublishAsync(
+            string topic,
+            IEnumerable<PubsubMessage> messages,
+            CancellationToken cancellationToken) => PublishAsync(
+                topic,
+                messages,
+                new CallSettings { CancellationToken = cancellationToken });
 
         /// <summary>
         /// Adds one or more messages to the topic. Generates `NOT_FOUND` if the topic
@@ -253,16 +285,26 @@ namespace Google.Pubsub.V1
         /// Gets the configuration of a topic.
         /// </summary>
         /// <param name="topic">The name of the topic to get.</param>
-        /// <param name="cancellationToken">If not null, a <see cref="CancellationToken"/> to use for this RPC.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
         public virtual Task<Topic> GetTopicAsync(
             string topic,
-            CancellationToken? cancellationToken = null,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Gets the configuration of a topic.
+        /// </summary>
+        /// <param name="topic">The name of the topic to get.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual Task<Topic> GetTopicAsync(
+            string topic,
+            CancellationToken cancellationToken) => GetTopicAsync(
+                topic,
+                new CallSettings { CancellationToken = cancellationToken });
 
         /// <summary>
         /// Gets the configuration of a topic.
@@ -337,16 +379,30 @@ namespace Google.Pubsub.V1
         /// not deleted, but their `topic` field is set to `_deleted-topic_`.
         /// </summary>
         /// <param name="topic">Name of the topic to delete.</param>
-        /// <param name="cancellationToken">If not null, a <see cref="CancellationToken"/> to use for this RPC.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A Task containing the RPC response.</returns>
         public virtual Task DeleteTopicAsync(
             string topic,
-            CancellationToken? cancellationToken = null,
             CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Deletes the topic with the given name. Generates `NOT_FOUND` if the topic
+        /// does not exist. After a topic is deleted, a new topic may be created with
+        /// the same name; this is an entirely new topic with none of the old
+        /// configuration or subscriptions. Existing subscriptions to this topic are
+        /// not deleted, but their `topic` field is set to `_deleted-topic_`.
+        /// </summary>
+        /// <param name="topic">Name of the topic to delete.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual Task DeleteTopicAsync(
+            string topic,
+            CancellationToken cancellationToken) => DeleteTopicAsync(
+                topic,
+                new CallSettings { CancellationToken = cancellationToken });
 
         /// <summary>
         /// Deletes the topic with the given name. Generates `NOT_FOUND` if the topic
@@ -652,7 +708,6 @@ namespace Google.Pubsub.V1
         /// <returns>A Task containing the RPC response.</returns>
         public override Task DeleteTopicAsync(
             string topic,
-            CancellationToken? cancellationToken = null,
             CallSettings callSettings = null)
         {
             DeleteTopicRequest request = new DeleteTopicRequest
@@ -661,7 +716,7 @@ namespace Google.Pubsub.V1
             };
             return GrpcClient.DeleteTopicAsync(
                 request,
-                _clientHelper.BuildCallOptions(cancellationToken, callSettings)
+                _clientHelper.BuildCallOptions(null, callSettings)
             ).ResponseAsync;
         }
 


### PR DESCRIPTION
NOT FOR SUBMISSION

Add overload to async (non-pagestreaming) methods to separate CallSettings and CancellationToken - to remove ambiguity of which CancellationToken is actually used.
Demonstrated here only in PublisherClient.

If this is OK, port it to the code-gen.