### PR TITLE
Update StorageClient to follow the same static creation pattern as generated APIs

### DIFF
--- a/demo/Google.Storage.V1.Demo/Program.cs
+++ b/demo/Google.Storage.V1.Demo/Program.cs
@@ -113,7 +113,7 @@ namespace Google.Storage.V1.Demo
                 }
                 try
                 {
-                    var client = await StorageClient.FromApplicationCredentials("Demo");
+                    var client = await StorageClient.CreateAsync();
                     await command(client);
                     return 0;
                 }

--- a/src/Google.Storage.V1/StorageClient.cs
+++ b/src/Google.Storage.V1/StorageClient.cs
@@ -49,16 +49,6 @@ namespace Google.Storage.V1
         }
 
         /// <summary>
-        /// Constructs a new client by creating a <see cref="StorageService"/> which uses the
-        /// given <see cref="BaseClientService.Initializer"/> for request initialization.
-        /// </summary>
-        /// <param name="initializer">The initializer to use in the service. Must not be null.</param>
-        public StorageClient(BaseClientService.Initializer initializer)
-            : this(new StorageService(Preconditions.CheckNotNull(initializer, nameof(initializer))))
-        {
-        }
-
-        /// <summary>
         /// Asynchronously creates a <see cref="StorageClient"/>, using application default credentials if
         /// no credentials are specified.
         /// </summary>
@@ -88,12 +78,13 @@ namespace Google.Storage.V1
             {
                 credential = credential.CreateScoped(StorageService.Scope.DevstorageFullControl);
             }
-            var initializer = new BaseClientService.Initializer
+            var service = new StorageService(new BaseClientService.Initializer
             {
                 HttpClientInitializer = credential,
                 ApplicationName = "google-dotnet",
-            };
-            return new StorageClient(initializer);
+            });
+
+            return new StorageClient(service);
         }
 
         /// <summary>

--- a/src/Google.Storage.V1/StorageClient.cs
+++ b/src/Google.Storage.V1/StorageClient.cs
@@ -59,26 +59,39 @@ namespace Google.Storage.V1
         }
 
         /// <summary>
-        /// Asynchronously creates a new <see cref="StorageClient"/> from the default application credentials.
+        /// Asynchronously creates a <see cref="StorageClient"/>, using application default credentials if
+        /// no credentials are specified.
         /// </summary>
         /// <remarks>
-        /// The application credentials are available to developers by running <c>gcloud auth</c> from the
-        /// command line, and are available automatically on Google Cloud Platform hosts.
+        /// The credentials are scoped as necessary.
         /// </remarks>
-        /// <param name="applicationName">The name of the application to create a client for. Must not be null.</param>
-        /// <returns>A client configured with the application-default credentials.</returns>
-        public static async Task<StorageClient> FromApplicationCredentials(string applicationName)
+        /// <param name="credential">Optional <see cref="GoogleCredential"/>.</param>
+        /// <returns>The task representing the created <see cref="StorageClient"/>.</returns>
+        public static async Task<StorageClient> CreateAsync(GoogleCredential credential = null)
+            // If no credentials have been specified, we fetch them "properly asynchronously"
+            // to avoid the Task.Run in the synchronous call
+            => Create(credential ?? await GoogleCredential.GetApplicationDefaultAsync().ConfigureAwait(false));
+
+        /// <summary>
+        /// Synchronously creates a <see cref="StorageClient"/>, using application default credentials if
+        /// no credentials are specified.
+        /// </summary>
+        /// <remarks>
+        /// The credentials are scoped as necessary.
+        /// </remarks>
+        /// <param name="credential">Optional <see cref="GoogleCredential"/>.</param>
+        /// <returns>The created <see cref="StorageClient"/>.</returns>
+        public static StorageClient Create(GoogleCredential credential = null)
         {
-            Preconditions.CheckNotNull(applicationName, nameof(applicationName));
-            var credentials = await GoogleCredential.GetApplicationDefaultAsync();
-            if (credentials.IsCreateScopedRequired)
+            credential = credential ?? Task.Run(() => GoogleCredential.GetApplicationDefaultAsync()).Result;
+            if (credential.IsCreateScopedRequired)
             {
-                credentials = credentials.CreateScoped(StorageService.Scope.DevstorageFullControl);
+                credential = credential.CreateScoped(StorageService.Scope.DevstorageFullControl);
             }
             var initializer = new BaseClientService.Initializer
             {
-                HttpClientInitializer = credentials,
-                ApplicationName = applicationName,
+                HttpClientInitializer = credential,
+                ApplicationName = "google-dotnet",
             };
             return new StorageClient(initializer);
         }

--- a/test/Google.Storage.V1.IntegrationTests/CloudConfiguration.cs
+++ b/test/Google.Storage.V1.IntegrationTests/CloudConfiguration.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Threading.Tasks;
 
 namespace Google.Storage.V1.IntegrationTests
 {
@@ -36,7 +35,7 @@ namespace Google.Storage.V1.IntegrationTests
         private CloudConfiguration(string project)
         {
             Project = project;
-            Client = Task.Run(async () => await StorageClient.FromApplicationCredentials("Test")).Result;
+            Client = StorageClient.Create();
             TempBucketPrefix = Project + "_integrationtests-";
         }
 


### PR DESCRIPTION
To create a StorageClient, there are now four options:
- Pass in an existing StorageService
- Pass in an existing initializer (less likely to be useful; drop?)
- Call the static Create method and pass in optional credentials
- Call the static CreateAsync method and pass in optional credentials

Now we *could* have a synchronous constructor which uses Task.Run to get the credentials,
basically like Create. In our other APIs we have an abstract base class and then a concrete derived
class, making the constructor route a no-no... I haven't gone for that here, although we could if
we wanted to.

We could also have an extension method of ToStorageClient on StorageService if that proved useful.

For comments: @csells @SurferJeffAtGoogle @chrsmith @ivannaranjo @remi 