### PR TITLE
Remove "Improve this doc" button from github pages

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -23,7 +23,8 @@
       }
     ],
     "globalMetadata": {
-      "_appTitle": "Google Cloud APIs"
+      "_appTitle": "Google Cloud APIs",
+      "_disableContribution": true
     },
     "dest": "_site"
   }


### PR DESCRIPTION
Fixes #103.

Eventually we'll want to re-enable it, but I think we'll want a bit more
nuance first. (The 404 is just because the pages were built on a branch,
but it doesn't do exactly what we want anyway.)

Will rebuild docs when this is in.