### PR TITLE
Trying retry

### DIFF
--- a/src/Google.Pubsub.V1/PublisherClient.cs
+++ b/src/Google.Pubsub.V1/PublisherClient.cs
@@ -63,11 +63,11 @@ namespace Google.Pubsub.V1
             RetrySettings.FilterForStatusCodes();
 
         public static BackoffSettings GetDefaultRetryBackoff() => new BackoffSettings
-            {
-                Delay = TimeSpan.FromMilliseconds(100),
-                DelayMultiplier = 1.2,
-                MaxDelay = TimeSpan.FromMilliseconds(1000),
-            };
+        {
+            Delay = TimeSpan.FromMilliseconds(100),
+            DelayMultiplier = 1.2,
+            MaxDelay = TimeSpan.FromMilliseconds(1000),
+        };
 
         public static BackoffSettings GetDefaultTimeoutBackoff() => new BackoffSettings
         {
@@ -76,7 +76,8 @@ namespace Google.Pubsub.V1
             MaxDelay = TimeSpan.FromMilliseconds(30000),
         };
 
-        public RetrySettings CreateTopicRetry { get; set; } = new RetrySettings {
+        public RetrySettings CreateTopicRetry { get; set; } = new RetrySettings
+        {
             RetryBackoff = GetDefaultRetryBackoff(),
             TimeoutBackoff = GetDefaultTimeoutBackoff(),
             RetryFilter = IdempotentRetryFilter


### PR DESCRIPTION
NOT FOR SUBMISSION - and this is not expected to build successfully.

Initial attempt at what retry code might look like in auto-gen'ed code.

The retry settings are taken directly from the relevant yaml config
file, and maintain the definition structure from the yaml. E.g. the
"Idempotent" of "IdempotentRetryFilter", and the "Default" in
"GetDefault[Retry|Timeout]Backoff()".

Separate RetrySettings are defined for every method; every method
defaults to having retry enabled; setting the relevant setting to null
would disable retry. This may or may not be what we actually want.

GAX currently only defines ApiCallable, I suspect it'll be useful to
have separate sync/async ApiCallables. I've pretend these exist in this
code; plus ClientHelper methods to create these callables, optionally
with retry.

I've only edited two RPCs to actually use retry, one "normal"
(CreateTopic) and one pagestreaming (ListTopics).
When this is code-gen'ed, all methods will have the changes applied.