### PR TITLE
Add explicit alpha/beta notices, and a link to the public myget feed.

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -26,6 +26,7 @@
       "_appTitle": "Google Cloud APIs",
       "_disableContribution": true
     },
+    "overwrite": "extra/*.md",
     "dest": "_site"
   }
 }

--- a/docs/extra/alpha.md
+++ b/docs/extra/alpha.md
@@ -1,0 +1,46 @@
+---
+uid: Google.Datastore.V1Beta3.DatastoreClient
+---
+
+> # Note: alpha release
+> This is alpha release of the Cloud Datastore API.
+
+---
+uid: Google.Datastore.V1Beta3
+---
+
+> # Note: alpha release
+> This is alpha release of the Cloud Datastore API.
+
+---
+uid: Google.Pubsub.V1
+---
+
+> # Note: alpha release
+> This is alpha release of the Cloud Pub/sub API.
+
+---
+uid: Google.Pubsub.V1.PublisherClient
+---
+
+> # Note: alpha release
+> This is alpha release of the Cloud Pub/sub API.
+
+---
+uid: Google.Pubsub.V1.SubscriberClient
+---
+
+> # Note: alpha release
+> This is alpha release of the Cloud Pub/sub API.
+
+---
+uid: Google.Logging.V2.LoggingServiceV2Client
+---
+
+> # Note: this is an alpha release of the Stackdriver Logging API.
+
+---
+uid: Google.Logging.V2
+---
+
+> # Note: this is an alpha release of the Stackdriver Logging API.

--- a/docs/extra/beta.md
+++ b/docs/extra/beta.md
@@ -1,0 +1,13 @@
+---
+uid: Google.Storage.V1.StorageClient
+---
+
+> # Note: beta release
+> This is a beta release of the Cloud Storage API.
+
+---
+uid: Google.Storage.V1
+---
+
+> # Note: beta release
+> This is a beta release of the Cloud Storage API.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,14 @@
 This is preliminary documentation for the Google Cloud APIs
 repository.
 
+# Beta APIs
+
+These APIs are available from [nuget.org](https://nuget.org) and can
+be installed by most users without reconfiguring their build
+environment at all. There is no guarantee that the API surface will
+stay stable between beta and full release, but we have high confidence
+that the libraries work and are usable.
+
 ## Google.Storage.V1
 
 A wrapper library over
@@ -11,6 +19,17 @@ for working with [Google Cloud Storage](https://cloud.google.com/storage/)
 
 Common operations are exposed via the
 [`StorageClient`](obj/api/Google.Storage.V1.StorageClient.yml) class.
+
+# Alpha APIs
+
+These APIs are available from Google's [public myget
+feed](http://https://www.myget.org/gallery/google-dotnet-public),
+which you will need to configure within your build system.
+
+These APIs are even more likely to have significant surface
+changes over time, and may fail or have usability issues. Still, if
+you would like to experiment with them, we would welcome your
+feedback.
 
 ## Google.Pubsub.V1
 


### PR DESCRIPTION
The "extra" directory allows us to add extra documentation to any API
documentation; it's a handy way of adding alpha/beta notices here.