### PR TITLE
Implement the abstract class / derived class pattern for Storage

### DIFF
--- a/src/Google.Storage.V1/StorageClient.DeleteObject.cs
+++ b/src/Google.Storage.V1/StorageClient.DeleteObject.cs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Apis.Storage.v1;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Storage.V1
 {
-    public partial class StorageClient
+    public abstract partial class StorageClient
     {
         /// <summary>
         /// Deletes a version of the specified object synchronously.
@@ -46,9 +46,9 @@ namespace Google.Storage.V1
         /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
         /// <param name="options">Additional options for the operation. May be null, in which case appropriate
         /// defaults will be used.</param>
-        public void DeleteObject(string bucket, string objectName, DeleteObjectOptions options = null)
+        public virtual void DeleteObject(string bucket, string objectName, DeleteObjectOptions options = null)
         {
-            CreateDeleteObjectRequest(bucket, objectName, options).Execute();
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -78,13 +78,13 @@ namespace Google.Storage.V1
         /// defaults will be used.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public Task DeleteObjectAsync(
+        public virtual Task DeleteObjectAsync(
             string bucket,
             string objectName,
             DeleteObjectOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return CreateDeleteObjectRequest(bucket, objectName, options).ExecuteAsync(cancellationToken);
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -113,9 +113,9 @@ namespace Google.Storage.V1
         /// <param name="obj">Object to delete. Must not be null, and must have the name and bucket populated.</param>
         /// <param name="options">Additional options for the operation. May be null, in which case appropriate
         /// defaults will be used.</param>
-        public void DeleteObject(Object obj, DeleteObjectOptions options = null)
+        public virtual void DeleteObject(Object obj, DeleteObjectOptions options = null)
         {
-            CreateDeleteObjectRequest(obj, options).Execute();
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -146,26 +146,9 @@ namespace Google.Storage.V1
         /// defaults will be used.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public Task DeleteObjectAsync(Object obj, DeleteObjectOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task DeleteObjectAsync(Object obj, DeleteObjectOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return CreateDeleteObjectRequest(obj, options).ExecuteAsync(cancellationToken);
-        }
-
-        private ObjectsResource.DeleteRequest CreateDeleteObjectRequest(Object obj, DeleteObjectOptions options)
-        {
-            ValidateObject(obj, nameof(obj));
-            var request = Service.Objects.Delete(obj.Bucket, obj.Name);
-            options?.ModifyRequest(request);
-            return request;
-        }
-
-        private ObjectsResource.DeleteRequest CreateDeleteObjectRequest(string bucket, string name, DeleteObjectOptions options)
-        {
-            ValidateBucket(bucket);
-            Preconditions.CheckNotNull(name, nameof(name));
-            var request = Service.Objects.Delete(bucket, name);
-            options?.ModifyRequest(request);
-            return request;
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Google.Storage.V1/StorageClient.DownloadObject.cs
+++ b/src/Google.Storage.V1/StorageClient.DownloadObject.cs
@@ -21,7 +21,7 @@ using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Storage.V1
 {
-    public partial class StorageClient
+    public abstract partial class StorageClient
     {
         /// <summary>
         /// Downloads the data for an object from storage synchronously, into a specified stream.
@@ -32,15 +32,14 @@ namespace Google.Storage.V1
         /// <param name="options">Additional options for the download. May be null, in which case appropriate
         /// defaults will be used.</param>
         /// <param name="progress">Progress reporter for the download. May be null.</param>
-        public void DownloadObject(
+        public virtual void DownloadObject(
             string bucket,
             string objectName,
             Stream destination,
             DownloadObjectOptions options = null,
             IProgress<IDownloadProgress> progress = null)
         {
-            var baseUri = GetBaseUri(bucket, objectName);
-            DownloadObjectImpl(baseUri, destination, options, progress);
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -54,7 +53,7 @@ namespace Google.Storage.V1
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="progress">Progress reporter for the download. May be null.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public Task DownloadObjectAsync(
+        public virtual Task DownloadObjectAsync(
             string bucket,
             string objectName,
             Stream destination,
@@ -62,8 +61,7 @@ namespace Google.Storage.V1
             CancellationToken cancellationToken = default(CancellationToken),
             IProgress<IDownloadProgress> progress = null)
         {
-            var baseUri = GetBaseUri(bucket, objectName);
-            return DownloadObjectAsyncImpl(baseUri, destination, options, cancellationToken, progress);
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -77,14 +75,13 @@ namespace Google.Storage.V1
         /// <param name="options">Additional options for the download. May be null, in which case appropriate
         /// defaults will be used.</param>
         /// <param name="progress">Progress reporter for the download. May be null.</param>
-        public void DownloadObject(
+        public virtual void DownloadObject(
             Object source,
             Stream destination,
             DownloadObjectOptions options = null,
             IProgress<IDownloadProgress> progress = null)
         {
-            var baseUri = GetBaseUri(source);
-            DownloadObjectImpl(baseUri, destination, options, progress);
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -100,97 +97,14 @@ namespace Google.Storage.V1
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="progress">Progress reporter for the download. May be null.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public Task DownloadObjectAsync(
+        public virtual Task DownloadObjectAsync(
             Object source,
             Stream destination,
             DownloadObjectOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken),
             IProgress<IDownloadProgress> progress = null)
         {
-            var baseUri = GetBaseUri(source);
-            return DownloadObjectAsyncImpl(baseUri, destination, options, cancellationToken, progress);
-        }
-
-        /// <summary>
-        /// Constructs the media URL of an object from its bucket and name. This does not include the generation
-        /// or any preconditions. The returned string will always have a query parameter, so later query parameters
-        /// can unconditionally be appended with an "&amp;" prefix.
-        /// </summary>
-        private static string GetBaseUri(string bucket, string objectName)
-        {
-            ValidateBucket(bucket);
-            Preconditions.CheckNotNull(objectName, nameof(objectName));
-            return $"https://www.googleapis.com/download/storage/v1/b/{bucket}/o/{Uri.EscapeDataString(objectName)}?alt=media";
-        }
-
-        /// <summary>
-        /// Obtains the media URL of an object from its bucket and name.
-        /// The returned string will always have a query parameter, so later query parameters
-        /// can unconditionally be appended with an "&amp;" prefix.
-        /// </summary>
-        private string GetBaseUri(Object source)
-        {
-            ValidateObject(source, nameof(source));
-            return GetBaseUri(source.Bucket, source.Name);
-        }
-
-        private void DownloadObjectImpl(
-            string baseUri,
-            Stream destination,
-            DownloadObjectOptions options,
-            IProgress<IDownloadProgress> progress)
-        {
-            // URI will definitely not be null; that's constructed internally.
-            Preconditions.CheckNotNull(destination, nameof(destination));
-            var downloader = new MediaDownloader(Service);
-            options?.ModifyDownloader(downloader);
-            string uri = options == null ? baseUri : options.GetUri(baseUri);
-            if (progress != null)
-            {
-                downloader.ProgressChanged += progress.Report;
-                progress.Report(InitialDownloadProgress.Instance);
-            }
-            var result = downloader.Download(uri, destination);
-            if (result.Status == DownloadStatus.Failed)
-            {
-                throw result.Exception;
-            }
-        }
-
-        private async Task DownloadObjectAsyncImpl(
-            string baseUri,
-            Stream destination,
-            DownloadObjectOptions options,
-            CancellationToken cancellationToken,
-            IProgress<IDownloadProgress> progress)
-        {
-            Preconditions.CheckNotNull(destination, nameof(destination));
-            var downloader = new MediaDownloader(Service);
-            options?.ModifyDownloader(downloader);
-            string uri = options == null ? baseUri : options.GetUri(baseUri);
-            if (progress != null)
-            {
-                downloader.ProgressChanged += progress.Report;
-                // Avoid reporting progress synchronously in the original call.
-                await Task.Yield();
-                progress.Report(InitialDownloadProgress.Instance);
-            }
-            var result = await downloader.DownloadAsync(uri, destination, cancellationToken).ConfigureAwait(false);
-            if (result.Status == DownloadStatus.Failed)
-            {
-                throw result.Exception;
-            }
-        }
-
-        // MediaDownloader doesn't report progress until the first chunk has been fetched. It can be useful to
-        // report a status of "not started" immediately. This implementation of IDownloadProgress does that.
-        private sealed class InitialDownloadProgress : IDownloadProgress
-        {
-            internal static readonly IDownloadProgress Instance = new InitialDownloadProgress();
-
-            public long BytesDownloaded => 0;
-            public Exception Exception => null;
-            public DownloadStatus Status => DownloadStatus.NotStarted;
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Google.Storage.V1/StorageClient.GetObject.cs
+++ b/src/Google.Storage.V1/StorageClient.GetObject.cs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Apis.Storage.v1;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Storage.V1
 {
-    public partial class StorageClient
+    public abstract partial class StorageClient
     {
         /// <summary>
         /// Fetches the information about an object synchronously.
@@ -31,11 +31,9 @@ namespace Google.Storage.V1
         /// <param name="options">Additional options for the fetch operation. May be null, in which case appropriate
         /// defaults will be used.</param>
         /// <returns>The <see cref="Object"/> representation of the storage object.</returns>
-        public Object GetObject(string bucket, string objectName, GetObjectOptions options = null)
+        public virtual Object GetObject(string bucket, string objectName, GetObjectOptions options = null)
         {
-            ValidateBucket(bucket);
-            Preconditions.CheckNotNull(objectName, nameof(objectName));
-            return CreateRequest(bucket, objectName, options).Execute();
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -50,22 +48,13 @@ namespace Google.Storage.V1
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation, with a result returning the
         /// <see cref="Object"/> representation of the storage object.</returns>
-        public Task<Object> GetObjectAsync(
+        public virtual Task<Object> GetObjectAsync(
             string bucket,
             string objectName,
             GetObjectOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            ValidateBucket(bucket);
-            Preconditions.CheckNotNull(objectName, nameof(objectName));
-            return CreateRequest(bucket, objectName, options).ExecuteAsync(cancellationToken);
-        }
-
-        private ObjectsResource.GetRequest CreateRequest(string bucket, string objectName, GetObjectOptions options)
-        {
-            var request = Service.Objects.Get(bucket, objectName);
-            options?.ModifyRequest(request);
-            return request;
-        }
+            throw new NotImplementedException();
+        }        
     }
 }

--- a/src/Google.Storage.V1/StorageClient.ListBuckets.cs
+++ b/src/Google.Storage.V1/StorageClient.ListBuckets.cs
@@ -12,25 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Apis.Requests;
-using Google.Apis.Storage.v1;
 using Google.Apis.Storage.v1.Data;
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Google.Storage.V1
 {
     // ListBuckets methods on StorageClient
-    public partial class StorageClient
-    {
-        private static readonly PageStreamer<Bucket, BucketsResource.ListRequest, Buckets, string> s_bucketPageStreamer =
-            new PageStreamer<Bucket, BucketsResource.ListRequest, Buckets, string>(
-                (request, token) => request.PageToken = token,
-                buckets => buckets.NextPageToken,
-                buckets => buckets.Items);
-
+    public abstract partial class StorageClient
+    {        
         /// <summary>
         /// Asynchronously lists the buckets in a given project, returning the results as a list.
         /// </summary>
@@ -43,14 +35,12 @@ namespace Google.Storage.V1
         /// defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A list of buckets within the project.</returns>
-        public Task<IList<Bucket>> ListAllBucketsAsync(
+        public virtual Task<IList<Bucket>> ListAllBucketsAsync(
             string projectId,
             ListBucketsOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Preconditions.CheckNotNull(projectId, nameof(projectId));
-            var initialRequest = CreateListBucketsRequest(projectId, options);
-            return s_bucketPageStreamer.FetchAllAsync(initialRequest, cancellationToken);
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -65,18 +55,9 @@ namespace Google.Storage.V1
         /// <param name="options">The options for the operation. May be null, in which case
         /// defaults will be supplied.</param>
         /// <returns>A sequence of buckets within the project.</returns>
-        public IEnumerable<Bucket> ListBuckets(string projectId, ListBucketsOptions options = null)
+        public virtual IEnumerable<Bucket> ListBuckets(string projectId, ListBucketsOptions options = null)
         {
-            Preconditions.CheckNotNull(projectId, nameof(projectId));
-            var initialRequest = CreateListBucketsRequest(projectId, options);
-            return s_bucketPageStreamer.Fetch(initialRequest);
-        }
-
-        private BucketsResource.ListRequest CreateListBucketsRequest(string projectId, ListBucketsOptions options)
-        {
-            var request = Service.Buckets.List(projectId);
-            options?.ModifyRequest(request);
-            return request;
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Google.Storage.V1/StorageClient.ListObjects.cs
+++ b/src/Google.Storage.V1/StorageClient.ListObjects.cs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Apis.Requests;
-using Google.Apis.Storage.v1;
-using Google.Apis.Storage.v1.Data;
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Object = Google.Apis.Storage.v1.Data.Object;
@@ -24,14 +21,8 @@ using Object = Google.Apis.Storage.v1.Data.Object;
 namespace Google.Storage.V1
 {
     // ListObjects methods on StorageClient
-    public partial class StorageClient
+    public abstract partial class StorageClient
     {
-        private static readonly PageStreamer<Object, ObjectsResource.ListRequest, Objects, string> s_objectPageStreamer =
-            new PageStreamer<Object, ObjectsResource.ListRequest, Objects, string>(
-                (request, token) => request.PageToken = token,
-                objects => objects.NextPageToken,
-                objects => objects.Items);
-
         /// <summary>
         /// Asynchronously lists the objects in a given bucket, returning the results as a list.
         /// </summary>
@@ -46,16 +37,14 @@ namespace Google.Storage.V1
         /// defaults will be supplied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A list of objects within the bucket.</returns>
-        public Task<IList<Object>> ListAllObjectsAsync(
+        public virtual Task<IList<Object>> ListAllObjectsAsync(
             string bucket,
             string prefix,
             ListObjectsOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var initialRequest = CreateListObjectsRequest(bucket, prefix, options);
-            return s_objectPageStreamer.FetchAllAsync(initialRequest, cancellationToken);
+            throw new NotImplementedException();
         }
-
 
         /// <summary>
         /// Lists the objects in a given bucket, synchronously but lazily.
@@ -71,19 +60,9 @@ namespace Google.Storage.V1
         /// <param name="options">The options for the operation. May be null, in which case
         /// defaults will be supplied.</param>
         /// <returns>A sequence of objects within the bucket.</returns>
-        public IEnumerable<Object> ListObjects(string bucket, string prefix, ListObjectsOptions options = null)
+        public virtual IEnumerable<Object> ListObjects(string bucket, string prefix, ListObjectsOptions options = null)
         {
-            var initialRequest = CreateListObjectsRequest(bucket, prefix, options);
-            return s_objectPageStreamer.Fetch(initialRequest);
-        }
-
-        private ObjectsResource.ListRequest CreateListObjectsRequest(string bucket, string prefix, ListObjectsOptions options)
-        {
-            ValidateBucket(bucket);
-            var request = Service.Objects.List(bucket);
-            request.Prefix = prefix;
-            options?.ModifyRequest(request);
-            return request;
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Google.Storage.V1/StorageClient.UploadObject.cs
+++ b/src/Google.Storage.V1/StorageClient.UploadObject.cs
@@ -21,7 +21,7 @@ using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Storage.V1
 {
-    public partial class StorageClient
+    public abstract partial class StorageClient
     {
         /// <summary>
         /// Uploads the data for an object in storage synchronously, from a specified stream.
@@ -35,7 +35,7 @@ namespace Google.Storage.V1
         /// defaults will be used.</param>
         /// <param name="progress">Progress reporter for the upload. May be null.</param>
         /// <returns>The <see cref="Object"/> representation of the uploaded object.</returns>
-        public Object UploadObject(
+        public virtual Object UploadObject(
             string bucket,
             string objectName,
             string contentType,
@@ -43,12 +43,7 @@ namespace Google.Storage.V1
             UploadObjectOptions options = null,
             IProgress<IUploadProgress> progress = null)
         {
-            ValidateBucket(bucket);
-            Preconditions.CheckNotNull(objectName, nameof(objectName));
-            Preconditions.CheckNotNull(contentType, nameof(contentType));
-            return UploadObject(
-                new Object { Bucket = bucket, Name = objectName, ContentType = contentType },
-                source, options, progress);
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -61,10 +56,9 @@ namespace Google.Storage.V1
         /// <param name="source">The stream to read the data from. Must not be null.</param>
         /// <returns>A task representing the asynchronous operation, with a result returning the
         /// <see cref="Object"/> representation of the uploaded object.</returns>
-        public Task<Object> UploadObjectAsync(string bucket, string objectName, string contentType, Stream source)
+        public virtual Task<Object> UploadObjectAsync(string bucket, string objectName, string contentType, Stream source)
         {
-            return UploadObjectAsync(bucket, objectName, contentType, source,
-                options: null, cancellationToken: CancellationToken.None, progress: null);
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -81,7 +75,7 @@ namespace Google.Storage.V1
         /// <param name="progress">Progress reporter for the upload. May be null.</param>
         /// <returns>A task representing the asynchronous operation, with a result returning the
         /// <see cref="Object"/> representation of the uploaded object.</returns>
-        public Task<Object> UploadObjectAsync(
+        public virtual Task<Object> UploadObjectAsync(
             string bucket,
             string objectName,
             string contentType,
@@ -90,11 +84,7 @@ namespace Google.Storage.V1
             CancellationToken cancellationToken = default(CancellationToken),
             IProgress<IUploadProgress> progress = null)
         {
-            ValidateBucket(bucket);
-            Preconditions.CheckNotNull(objectName, nameof(objectName));
-            Preconditions.CheckNotNull(contentType, nameof(contentType));
-            return UploadObjectAsync(new Object { Bucket = bucket, Name = objectName, ContentType = contentType },
-                source, options, cancellationToken, progress);
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -107,27 +97,13 @@ namespace Google.Storage.V1
         /// defaults will be used.</param>
         /// <param name="progress">Progress reporter for the upload. May be null.</param>
         /// <returns>The <see cref="Object"/> representation of the uploaded object.</returns>
-        public Object UploadObject(
+        public virtual Object UploadObject(
             Object destination,
             Stream source,
             UploadObjectOptions options = null,
             IProgress<IUploadProgress> progress = null)
         {
-            ValidateObject(destination, nameof(destination));
-            Preconditions.CheckArgument(destination.ContentType != null, nameof(destination), "Object must have a ContentType");
-            Preconditions.CheckNotNull(source, nameof(source));
-            var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
-            options?.ModifyMediaUpload(mediaUpload);
-            if (progress != null)
-            {
-                mediaUpload.ProgressChanged += progress.Report;
-            }
-            var finalProgress = mediaUpload.Upload();
-            if (finalProgress.Exception != null)
-            {
-                throw finalProgress.Exception;
-            }
-            return mediaUpload.ResponseBody;
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -142,28 +118,14 @@ namespace Google.Storage.V1
         /// <param name="progress">Progress reporter for the upload. May be null.</param>
         /// <returns>A task representing the asynchronous operation, with a result returning the
         /// <see cref="Object"/> representation of the uploaded object.</returns>
-        public async Task<Object> UploadObjectAsync(
+        public virtual Task<Object> UploadObjectAsync(
             Object destination,
             Stream source,
             UploadObjectOptions options = null,
             CancellationToken cancellationToken = default(CancellationToken),
             IProgress<IUploadProgress> progress = null)
         {
-            ValidateObject(destination, nameof(destination));
-            Preconditions.CheckArgument(destination.ContentType != null, nameof(destination), "Object must have a ContentType");
-            Preconditions.CheckNotNull(source, nameof(source));
-            var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
-            options?.ModifyMediaUpload(mediaUpload);
-            if (progress != null)
-            {
-                mediaUpload.ProgressChanged += progress.Report;
-            }
-            var finalProgress = await mediaUpload.UploadAsync(cancellationToken).ConfigureAwait(false);
-            if (finalProgress.Exception != null)
-            {
-                throw finalProgress.Exception;
-            }
-            return mediaUpload.ResponseBody;
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Google.Storage.V1/StorageClient.cs
+++ b/src/Google.Storage.V1/StorageClient.cs
@@ -16,16 +16,26 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Storage.V1
 {
     /// <summary>
-    /// Wrapper around <see cref="StorageService"/> to provide simpler operations.
+    /// Abstract class providing operations for Google Cloud Storage.
     /// </summary>
-    public partial class StorageClient
+    /// <remarks>
+    /// <para>
+    /// This abstract class is provided to enable testability while permitting
+    /// additional operations to be added in the future. See <see cref="Create(GoogleCredential)"/>
+    /// and <see cref="CreateAsync(GoogleCredential)"/> to construct instances; alternatively, you can
+    /// construct a <see cref="StorageClientImpl"/> directly from a <see cref="StorageService"/>.
+    /// </para>
+    /// <para>
+    /// All instance methods declared in this class are virtual, with an implementation which simply
+    /// throws <see cref="NotImplementedException"/>. All these methods are overridden in <see cref="StorageClientImpl"/>.
+    /// </para>
+    /// </remarks>
+    public abstract partial class StorageClient
     {
         /// <summary>
         /// The underlying storage service object used by this client.
@@ -36,17 +46,7 @@ namespace Google.Storage.V1
         /// to use the same service object as the wrapper, in order to take advantage of its configuration (for authentication,
         /// application naming etc).
         /// </remarks>
-        public StorageService Service { get; }
-
-        /// <summary>
-        /// Constructs a new client wrapping the given <see cref="StorageService"/>.
-        /// </summary>
-        /// <param name="service">The service to wrap. Must not be null.</param>
-        public StorageClient(StorageService service)
-        {
-            Preconditions.CheckNotNull(service, nameof(service));
-            Service = service;
-        }
+        public virtual StorageService Service { get; }
 
         /// <summary>
         /// Asynchronously creates a <see cref="StorageClient"/>, using application default credentials if
@@ -84,46 +84,9 @@ namespace Google.Storage.V1
                 ApplicationName = "google-dotnet",
             });
 
-            return new StorageClient(service);
-        }
-
-        /// <summary>
-        /// Regular expression to be used for bucket validation when <see cref="ValidateBucket"/>
-        /// would throw the wrong exception.
-        /// </summary>
-        private static readonly Regex ValidBucketName = new Regex(@"^[0-9a-z.\-_]{1,222}$");
-
-        /// <summary>
-        /// Validates that a bucket only contains valid characters, and is not too long. This is far from
-        /// complete validation, but is all that's required to ensure that it's safe to include in a URL.
-        /// This method also checks for nullity, so callers don't need to do that first.
-        /// This method is internal rather than private for testing purposes.
-        /// </summary>
-        internal static void ValidateBucket(string bucket)
-        {
-            Preconditions.CheckNotNull(bucket, nameof(bucket));
-            if (!ValidBucketName.IsMatch(bucket))
-            {
-                throw new ArgumentException($"Invalid bucket name '{bucket}' - see https://cloud.google.com/storage/docs/bucket-naming", nameof(bucket));
-            }
+            return new StorageClientImpl(service);
         }
 
 
-        /// <summary>
-        /// Validates that the given Object has a "somewhat valid" (no URI encoding required) bucket name and an object name.
-        /// </summary>
-        /// <param name="obj">Object to validate</param>
-        /// <param name="paramName">The parameter name in the calling method</param>
-        private void ValidateObject(Object obj, string paramName)
-        {
-            Preconditions.CheckNotNull(obj, paramName);
-            Preconditions.CheckArgument(
-                obj.Name != null && obj.Bucket != null,
-                paramName,
-                "Object must have a name and bucket");
-            Preconditions.CheckArgument(ValidBucketName.IsMatch(obj.Bucket),
-                paramName,
-                "Object bucket '{0}' is invalid", obj.Bucket);
-        }
     }
 }

--- a/src/Google.Storage.V1/StorageClientImpl.DeleteObject.cs
+++ b/src/Google.Storage.V1/StorageClientImpl.DeleteObject.cs
@@ -1,0 +1,69 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Storage.v1;
+using System.Threading;
+using System.Threading.Tasks;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+namespace Google.Storage.V1
+{
+    public sealed partial class StorageClientImpl : StorageClient
+    {
+        /// <inheritdoc />
+        public override void DeleteObject(string bucket, string objectName, DeleteObjectOptions options = null)
+        {
+            CreateDeleteObjectRequest(bucket, objectName, options).Execute();
+        }
+
+        /// <inheritdoc />
+        public override Task DeleteObjectAsync(
+            string bucket,
+            string objectName,
+            DeleteObjectOptions options = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return CreateDeleteObjectRequest(bucket, objectName, options).ExecuteAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public override void DeleteObject(Object obj, DeleteObjectOptions options = null)
+        {
+            CreateDeleteObjectRequest(obj, options).Execute();
+        }
+
+        /// <inheritdoc />
+        public override Task DeleteObjectAsync(Object obj, DeleteObjectOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return CreateDeleteObjectRequest(obj, options).ExecuteAsync(cancellationToken);
+        }
+
+        private ObjectsResource.DeleteRequest CreateDeleteObjectRequest(Object obj, DeleteObjectOptions options)
+        {
+            ValidateObject(obj, nameof(obj));
+            var request = Service.Objects.Delete(obj.Bucket, obj.Name);
+            options?.ModifyRequest(request);
+            return request;
+        }
+
+        private ObjectsResource.DeleteRequest CreateDeleteObjectRequest(string bucket, string name, DeleteObjectOptions options)
+        {
+            ValidateBucket(bucket);
+            Preconditions.CheckNotNull(name, nameof(name));
+            var request = Service.Objects.Delete(bucket, name);
+            options?.ModifyRequest(request);
+            return request;
+        }
+    }
+}

--- a/src/Google.Storage.V1/StorageClientImpl.DownloadObject.cs
+++ b/src/Google.Storage.V1/StorageClientImpl.DownloadObject.cs
@@ -1,0 +1,156 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Download;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+namespace Google.Storage.V1
+{
+    public sealed partial class StorageClientImpl : StorageClient
+    {
+        /// <inheritdoc />
+        public override void DownloadObject(
+            string bucket,
+            string objectName,
+            Stream destination,
+            DownloadObjectOptions options = null,
+            IProgress<IDownloadProgress> progress = null)
+        {
+            var baseUri = GetBaseUri(bucket, objectName);
+            DownloadObjectImpl(baseUri, destination, options, progress);
+        }
+
+        /// <inheritdoc />
+        public override Task DownloadObjectAsync(
+            string bucket,
+            string objectName,
+            Stream destination,
+            DownloadObjectOptions options = null,
+            CancellationToken cancellationToken = default(CancellationToken),
+            IProgress<IDownloadProgress> progress = null)
+        {
+            var baseUri = GetBaseUri(bucket, objectName);
+            return DownloadObjectAsyncImpl(baseUri, destination, options, cancellationToken, progress);
+        }
+
+        /// <inheritdoc />
+        public override void DownloadObject(
+            Object source,
+            Stream destination,
+            DownloadObjectOptions options = null,
+            IProgress<IDownloadProgress> progress = null)
+        {
+            var baseUri = GetBaseUri(source);
+            DownloadObjectImpl(baseUri, destination, options, progress);
+        }
+
+        /// <inheritdoc />
+        public override Task DownloadObjectAsync(
+            Object source,
+            Stream destination,
+            DownloadObjectOptions options = null,
+            CancellationToken cancellationToken = default(CancellationToken),
+            IProgress<IDownloadProgress> progress = null)
+        {
+            var baseUri = GetBaseUri(source);
+            return DownloadObjectAsyncImpl(baseUri, destination, options, cancellationToken, progress);
+        }
+
+        /// <summary>
+        /// Constructs the media URL of an object from its bucket and name. This does not include the generation
+        /// or any preconditions. The returned string will always have a query parameter, so later query parameters
+        /// can unconditionally be appended with an "&amp;" prefix.
+        /// </summary>
+        private static string GetBaseUri(string bucket, string objectName)
+        {
+            ValidateBucket(bucket);
+            Preconditions.CheckNotNull(objectName, nameof(objectName));
+            return $"https://www.googleapis.com/download/storage/v1/b/{bucket}/o/{Uri.EscapeDataString(objectName)}?alt=media";
+        }
+
+        /// <summary>
+        /// Obtains the media URL of an object from its bucket and name.
+        /// The returned string will always have a query parameter, so later query parameters
+        /// can unconditionally be appended with an "&amp;" prefix.
+        /// </summary>
+        private string GetBaseUri(Object source)
+        {
+            ValidateObject(source, nameof(source));
+            return GetBaseUri(source.Bucket, source.Name);
+        }
+
+        private void DownloadObjectImpl(
+            string baseUri,
+            Stream destination,
+            DownloadObjectOptions options,
+            IProgress<IDownloadProgress> progress)
+        {
+            // URI will definitely not be null; that's constructed internally.
+            Preconditions.CheckNotNull(destination, nameof(destination));
+            var downloader = new MediaDownloader(Service);
+            options?.ModifyDownloader(downloader);
+            string uri = options == null ? baseUri : options.GetUri(baseUri);
+            if (progress != null)
+            {
+                downloader.ProgressChanged += progress.Report;
+                progress.Report(InitialDownloadProgress.Instance);
+            }
+            var result = downloader.Download(uri, destination);
+            if (result.Status == DownloadStatus.Failed)
+            {
+                throw result.Exception;
+            }
+        }
+
+        private async Task DownloadObjectAsyncImpl(
+            string baseUri,
+            Stream destination,
+            DownloadObjectOptions options,
+            CancellationToken cancellationToken,
+            IProgress<IDownloadProgress> progress)
+        {
+            Preconditions.CheckNotNull(destination, nameof(destination));
+            var downloader = new MediaDownloader(Service);
+            options?.ModifyDownloader(downloader);
+            string uri = options == null ? baseUri : options.GetUri(baseUri);
+            if (progress != null)
+            {
+                downloader.ProgressChanged += progress.Report;
+                // Avoid reporting progress synchronously in the original call.
+                await Task.Yield();
+                progress.Report(InitialDownloadProgress.Instance);
+            }
+            var result = await downloader.DownloadAsync(uri, destination, cancellationToken).ConfigureAwait(false);
+            if (result.Status == DownloadStatus.Failed)
+            {
+                throw result.Exception;
+            }
+        }
+
+        // MediaDownloader doesn't report progress until the first chunk has been fetched. It can be useful to
+        // report a status of "not started" immediately. This implementation of IDownloadProgress does that.
+        private sealed class InitialDownloadProgress : IDownloadProgress
+        {
+            internal static readonly IDownloadProgress Instance = new InitialDownloadProgress();
+
+            public long BytesDownloaded => 0;
+            public Exception Exception => null;
+            public DownloadStatus Status => DownloadStatus.NotStarted;
+        }
+    }
+}

--- a/src/Google.Storage.V1/StorageClientImpl.GetObject.cs
+++ b/src/Google.Storage.V1/StorageClientImpl.GetObject.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Storage.v1;
+using System.Threading;
+using System.Threading.Tasks;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+namespace Google.Storage.V1
+{
+    public sealed partial class StorageClientImpl : StorageClient
+    {
+        /// <inheritdoc />
+        public override Object GetObject(string bucket, string objectName, GetObjectOptions options = null)
+        {
+            ValidateBucket(bucket);
+            Preconditions.CheckNotNull(objectName, nameof(objectName));
+            return CreateRequest(bucket, objectName, options).Execute();
+        }
+
+        /// <inheritdoc />
+        public override Task<Object> GetObjectAsync(
+            string bucket,
+            string objectName,
+            GetObjectOptions options = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            ValidateBucket(bucket);
+            Preconditions.CheckNotNull(objectName, nameof(objectName));
+            return CreateRequest(bucket, objectName, options).ExecuteAsync(cancellationToken);
+        }
+
+        private ObjectsResource.GetRequest CreateRequest(string bucket, string objectName, GetObjectOptions options)
+        {
+            var request = Service.Objects.Get(bucket, objectName);
+            options?.ModifyRequest(request);
+            return request;
+        }
+    }
+}

--- a/src/Google.Storage.V1/StorageClientImpl.ListBuckets.cs
+++ b/src/Google.Storage.V1/StorageClientImpl.ListBuckets.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Requests;
+using Google.Apis.Storage.v1;
+using Google.Apis.Storage.v1.Data;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Storage.V1
+{
+    // ListBuckets methods on StorageClient
+    public sealed partial class StorageClientImpl : StorageClient
+    {
+        private static readonly PageStreamer<Bucket, BucketsResource.ListRequest, Buckets, string> s_bucketPageStreamer =
+            new PageStreamer<Bucket, BucketsResource.ListRequest, Buckets, string>(
+                (request, token) => request.PageToken = token,
+                buckets => buckets.NextPageToken,
+                buckets => buckets.Items);
+
+        /// <inheritdoc />
+        public override Task<IList<Bucket>> ListAllBucketsAsync(
+            string projectId,
+            ListBucketsOptions options = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Preconditions.CheckNotNull(projectId, nameof(projectId));
+            var initialRequest = CreateListBucketsRequest(projectId, options);
+            return s_bucketPageStreamer.FetchAllAsync(initialRequest, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<Bucket> ListBuckets(string projectId, ListBucketsOptions options = null)
+        {
+            Preconditions.CheckNotNull(projectId, nameof(projectId));
+            var initialRequest = CreateListBucketsRequest(projectId, options);
+            return s_bucketPageStreamer.Fetch(initialRequest);
+        }
+
+        private BucketsResource.ListRequest CreateListBucketsRequest(string projectId, ListBucketsOptions options)
+        {
+            var request = Service.Buckets.List(projectId);
+            options?.ModifyRequest(request);
+            return request;
+        }
+    }
+}

--- a/src/Google.Storage.V1/StorageClientImpl.ListObjects.cs
+++ b/src/Google.Storage.V1/StorageClientImpl.ListObjects.cs
@@ -1,0 +1,61 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Requests;
+using Google.Apis.Storage.v1;
+using Google.Apis.Storage.v1.Data;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+namespace Google.Storage.V1
+{
+    // ListObjects methods on StorageClient
+    public sealed partial class StorageClientImpl : StorageClient
+    {
+        private static readonly PageStreamer<Object, ObjectsResource.ListRequest, Objects, string> s_objectPageStreamer =
+            new PageStreamer<Object, ObjectsResource.ListRequest, Objects, string>(
+                (request, token) => request.PageToken = token,
+                objects => objects.NextPageToken,
+                objects => objects.Items);
+
+        /// <inheritdoc />
+        public override Task<IList<Object>> ListAllObjectsAsync(
+            string bucket,
+            string prefix,
+            ListObjectsOptions options = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var initialRequest = CreateListObjectsRequest(bucket, prefix, options);
+            return s_objectPageStreamer.FetchAllAsync(initialRequest, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<Object> ListObjects(string bucket, string prefix, ListObjectsOptions options = null)
+        {
+            var initialRequest = CreateListObjectsRequest(bucket, prefix, options);
+            return s_objectPageStreamer.Fetch(initialRequest);
+        }
+
+        private ObjectsResource.ListRequest CreateListObjectsRequest(string bucket, string prefix, ListObjectsOptions options)
+        {
+            ValidateBucket(bucket);
+            var request = Service.Objects.List(bucket);
+            request.Prefix = prefix;
+            options?.ModifyRequest(request);
+            return request;
+        }
+    }
+}

--- a/src/Google.Storage.V1/StorageClientImpl.UploadObject.cs
+++ b/src/Google.Storage.V1/StorageClientImpl.UploadObject.cs
@@ -1,0 +1,116 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Upload;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+namespace Google.Storage.V1
+{
+    public sealed partial class StorageClientImpl : StorageClient
+    {
+        /// <inheritdoc />
+        public override Object UploadObject(
+            string bucket,
+            string objectName,
+            string contentType,
+            Stream source,
+            UploadObjectOptions options = null,
+            IProgress<IUploadProgress> progress = null)
+        {
+            ValidateBucket(bucket);
+            Preconditions.CheckNotNull(objectName, nameof(objectName));
+            Preconditions.CheckNotNull(contentType, nameof(contentType));
+            return UploadObject(
+                new Object { Bucket = bucket, Name = objectName, ContentType = contentType },
+                source, options, progress);
+        }
+
+        /// <inheritdoc />
+        public override Task<Object> UploadObjectAsync(string bucket, string objectName, string contentType, Stream source)
+        {
+            return UploadObjectAsync(bucket, objectName, contentType, source,
+                options: null, cancellationToken: CancellationToken.None, progress: null);
+        }
+
+        /// <inheritdoc />
+        public override Task<Object> UploadObjectAsync(
+            string bucket,
+            string objectName,
+            string contentType,
+            Stream source,
+            UploadObjectOptions options = null,
+            CancellationToken cancellationToken = default(CancellationToken),
+            IProgress<IUploadProgress> progress = null)
+        {
+            ValidateBucket(bucket);
+            Preconditions.CheckNotNull(objectName, nameof(objectName));
+            Preconditions.CheckNotNull(contentType, nameof(contentType));
+            return UploadObjectAsync(new Object { Bucket = bucket, Name = objectName, ContentType = contentType },
+                source, options, cancellationToken, progress);
+        }
+
+        /// <inheritdoc />
+        public override Object UploadObject(
+            Object destination,
+            Stream source,
+            UploadObjectOptions options = null,
+            IProgress<IUploadProgress> progress = null)
+        {
+            ValidateObject(destination, nameof(destination));
+            Preconditions.CheckArgument(destination.ContentType != null, nameof(destination), "Object must have a ContentType");
+            Preconditions.CheckNotNull(source, nameof(source));
+            var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
+            options?.ModifyMediaUpload(mediaUpload);
+            if (progress != null)
+            {
+                mediaUpload.ProgressChanged += progress.Report;
+            }
+            var finalProgress = mediaUpload.Upload();
+            if (finalProgress.Exception != null)
+            {
+                throw finalProgress.Exception;
+            }
+            return mediaUpload.ResponseBody;
+        }
+
+        /// <inheritdoc />
+        public override async Task<Object> UploadObjectAsync(
+            Object destination,
+            Stream source,
+            UploadObjectOptions options = null,
+            CancellationToken cancellationToken = default(CancellationToken),
+            IProgress<IUploadProgress> progress = null)
+        {
+            ValidateObject(destination, nameof(destination));
+            Preconditions.CheckArgument(destination.ContentType != null, nameof(destination), "Object must have a ContentType");
+            Preconditions.CheckNotNull(source, nameof(source));
+            var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
+            options?.ModifyMediaUpload(mediaUpload);
+            if (progress != null)
+            {
+                mediaUpload.ProgressChanged += progress.Report;
+            }
+            var finalProgress = await mediaUpload.UploadAsync(cancellationToken).ConfigureAwait(false);
+            if (finalProgress.Exception != null)
+            {
+                throw finalProgress.Exception;
+            }
+            return mediaUpload.ResponseBody;
+        }
+    }
+}

--- a/src/Google.Storage.V1/StorageClientImpl.cs
+++ b/src/Google.Storage.V1/StorageClientImpl.cs
@@ -1,0 +1,84 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Storage.v1;
+using System;
+using System.Text.RegularExpressions;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+namespace Google.Storage.V1
+{
+    /// <summary>
+    /// Wrapper around <see cref="StorageService"/> to provide simpler operations.
+    /// </summary>
+    /// <remarks>
+    /// This is the "default" implementation of <see cref="StorageClient"/>. Most client code
+    /// should refer to <see cref="StorageClient"/>, creating instances with
+    /// <see cref="StorageClient.Create(Apis.Auth.OAuth2.GoogleCredential)"/> and
+    /// <see cref="StorageClient.CreateAsync(Apis.Auth.OAuth2.GoogleCredential)"/>. The constructor
+    /// of this class is public for the sake of constructor-based dependency injection.
+    /// </remarks>
+    public sealed partial class StorageClientImpl : StorageClient
+    {
+        /// <inheritdoc />
+        public override StorageService Service { get; }
+
+        /// <summary>
+        /// Constructs a new client wrapping the given <see cref="StorageService"/>.
+        /// </summary>
+        /// <param name="service">The service to wrap. Must not be null.</param>
+        public StorageClientImpl(StorageService service)
+        {            
+            Service = Preconditions.CheckNotNull(service, nameof(service));
+        }
+
+        /// <summary>
+        /// Regular expression to be used for bucket validation when <see cref="ValidateBucket"/>
+        /// would throw the wrong exception.
+        /// </summary>
+        private static readonly Regex ValidBucketName = new Regex(@"^[0-9a-z.\-_]{1,222}$");
+
+        /// <summary>
+        /// Validates that a bucket only contains valid characters, and is not too long. This is far from
+        /// complete validation, but is all that's required to ensure that it's safe to include in a URL.
+        /// This method also checks for nullity, so callers don't need to do that first.
+        /// This method is internal rather than private for testing purposes.
+        /// </summary>
+        internal static void ValidateBucket(string bucket)
+        {
+            Preconditions.CheckNotNull(bucket, nameof(bucket));
+            if (!ValidBucketName.IsMatch(bucket))
+            {
+                throw new ArgumentException($"Invalid bucket name '{bucket}' - see https://cloud.google.com/storage/docs/bucket-naming", nameof(bucket));
+            }
+        }
+
+        /// <summary>
+        /// Validates that the given Object has a "somewhat valid" (no URI encoding required) bucket name and an object name.
+        /// </summary>
+        /// <param name="obj">Object to validate</param>
+        /// <param name="paramName">The parameter name in the calling method</param>
+        private void ValidateObject(Object obj, string paramName)
+        {
+            Preconditions.CheckNotNull(obj, paramName);
+            Preconditions.CheckArgument(
+                obj.Name != null && obj.Bucket != null,
+                paramName,
+                "Object must have a name and bucket");
+            Preconditions.CheckArgument(ValidBucketName.IsMatch(obj.Bucket),
+                paramName,
+                "Object bucket '{0}' is invalid", obj.Bucket);
+        }
+    }
+}

--- a/test/Google.Storage.V1.Tests/BucketValidationTest.cs
+++ b/test/Google.Storage.V1.Tests/BucketValidationTest.cs
@@ -25,7 +25,7 @@ namespace Google.Storage.V1.Tests
         [InlineData("numbers012346789")]
         public void ValidBucketNames(string bucket)
         {
-            StorageClient.ValidateBucket(bucket);
+            StorageClientImpl.ValidateBucket(bucket);
         }
 
         [Theory]
@@ -40,7 +40,7 @@ namespace Google.Storage.V1.Tests
         [InlineData("invalid-punctuation6%")]
         public void InvalidBucketNames(string bucket)
         {
-            var exception = Assert.ThrowsAny<ArgumentException>(() => StorageClient.ValidateBucket(bucket));
+            var exception = Assert.ThrowsAny<ArgumentException>(() => StorageClientImpl.ValidateBucket(bucket));
             Assert.Equal("bucket", exception.ParamName);
             Assert.Contains(bucket, exception.Message);
         }


### PR DESCRIPTION
Currently the inheritdoc tag does not work in docfx, but users should be
referring to the StorageClient documentation anyway, and I definitely don't want
redundancy in manually-written documentation.