### PR TITLE
Fix navigation for alpha/beta docs.

### DIFF
--- a/docs/extra/alpha.md
+++ b/docs/extra/alpha.md
@@ -2,45 +2,47 @@
 uid: Google.Datastore.V1Beta3.DatastoreClient
 ---
 
-> # Note: alpha release
+> **Note: alpha release**  
 > This is alpha release of the Cloud Datastore API.
 
 ---
 uid: Google.Datastore.V1Beta3
 ---
 
-> # Note: alpha release
+> **Note: alpha release**  
 > This is alpha release of the Cloud Datastore API.
 
 ---
 uid: Google.Pubsub.V1
 ---
 
-> # Note: alpha release
+> **Note: alpha release**  
 > This is alpha release of the Cloud Pub/sub API.
 
 ---
 uid: Google.Pubsub.V1.PublisherClient
 ---
 
-> # Note: alpha release
+> **Note: alpha release**  
 > This is alpha release of the Cloud Pub/sub API.
 
 ---
 uid: Google.Pubsub.V1.SubscriberClient
 ---
 
-> # Note: alpha release
+> **Note: alpha release**  
 > This is alpha release of the Cloud Pub/sub API.
 
 ---
 uid: Google.Logging.V2.LoggingServiceV2Client
 ---
 
+> **Note: alpha release**  
 > # Note: this is an alpha release of the Stackdriver Logging API.
 
 ---
 uid: Google.Logging.V2
 ---
 
+> **Note: alpha release**  
 > # Note: this is an alpha release of the Stackdriver Logging API.

--- a/docs/extra/beta.md
+++ b/docs/extra/beta.md
@@ -2,12 +2,12 @@
 uid: Google.Storage.V1.StorageClient
 ---
 
-> # Note: beta release
+> **Note: beta release**  
 > This is a beta release of the Cloud Storage API.
 
 ---
 uid: Google.Storage.V1
 ---
 
-> # Note: beta release
+> **Note: beta release**  
 > This is a beta release of the Cloud Storage API.


### PR DESCRIPTION
Having a heading in the remarks section breaks the docfx navigation,
so I've just made it a line on its own, in bold.

Note that the trailing whitespace is deliberate and required in order to
generate a line break.