### PR TITLE
Introduce StorageClientImpl.ApplicationName

### DIFF
--- a/src/Google.Storage.V1/StorageClient.cs
+++ b/src/Google.Storage.V1/StorageClient.cs
@@ -81,12 +81,10 @@ namespace Google.Storage.V1
             var service = new StorageService(new BaseClientService.Initializer
             {
                 HttpClientInitializer = credential,
-                ApplicationName = "google-dotnet",
+                ApplicationName = StorageClientImpl.ApplicationName,
             });
 
             return new StorageClientImpl(service);
         }
-
-
     }
 }

--- a/src/Google.Storage.V1/StorageClientImpl.cs
+++ b/src/Google.Storage.V1/StorageClientImpl.cs
@@ -31,6 +31,36 @@ namespace Google.Storage.V1
     /// </remarks>
     public sealed partial class StorageClientImpl : StorageClient
     {
+        private static readonly object _applicationNameLock = new object();
+        private static string _applicationName = "gcloud-dotnet";
+
+        /// <summary>
+        /// The default application name used when creating a <see cref="StorageService"/>.
+        /// Defaults to "gcloud-dotnet"; must not be null.
+        /// </summary>
+        /// <remarks>
+        /// Most applications will never want to set this, which is why it's in this class rather than
+        /// <see cref="StorageClient"/>.
+        /// </remarks>
+        public static string ApplicationName
+        {
+            get
+            {
+                lock (_applicationNameLock)
+                {
+                    return _applicationName;
+                }
+            }
+            set
+            {
+                Preconditions.CheckNotNull(value, nameof(value));
+                lock (_applicationNameLock)
+                {
+                    _applicationName = value;
+                }
+            }
+        }
+
         /// <inheritdoc />
         public override StorageService Service { get; }
 


### PR DESCRIPTION
This is used when constructing new instances of StorageClient without specifying
a StorageService. Most applications will never need this, which is why it's
somewhat hidden away - as client construction is basically the first thing
we do, it's best to avoid overcomplicating it.