### PR TITLE
First pass at introducing snippets using docfx

### DIFF
--- a/GoogleApis.sln
+++ b/GoogleApis.sln
@@ -39,6 +39,10 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Datastore.V1Beta3.De
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Datastore.V1Beta3.Tests", "test\Google.Datastore.V1Beta3.Tests\Google.Datastore.V1Beta3.Tests.xproj", "{FD2FAD82-6719-4E1B-9291-7F8CDF819A3B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "snippets", "snippets", "{F638F51C-C1C3-449B-ADAE-8196073649A5}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Pubsub.V1.Snippets", "snippets\Google.Pubsub.V1.Snippets\Google.Pubsub.V1.Snippets.xproj", "{60E5F4C2-7A10-41F1-A247-14C346A8E33A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -89,6 +93,10 @@ Global
 		{FD2FAD82-6719-4E1B-9291-7F8CDF819A3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD2FAD82-6719-4E1B-9291-7F8CDF819A3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD2FAD82-6719-4E1B-9291-7F8CDF819A3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60E5F4C2-7A10-41F1-A247-14C346A8E33A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60E5F4C2-7A10-41F1-A247-14C346A8E33A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60E5F4C2-7A10-41F1-A247-14C346A8E33A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60E5F4C2-7A10-41F1-A247-14C346A8E33A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -105,5 +113,6 @@ Global
 		{4DA2E647-3A2B-448B-B1F5-034750BBA5B6} = {AC0CC83C-0448-419E-914E-E63036A77BD9}
 		{1F86EC95-80F1-432F-BB1C-F894ADA08614} = {DB076941-24F5-4F6C-9060-1EA9E2AC9887}
 		{FD2FAD82-6719-4E1B-9291-7F8CDF819A3B} = {F87E02E7-3142-4439-8938-42DD79337135}
+		{60E5F4C2-7A10-41F1-A247-14C346A8E33A} = {F638F51C-C1C3-449B-ADAE-8196073649A5}
 	EndGlobalSection
 EndGlobal

--- a/docs/extra/PubisherClientSnippets.md
+++ b/docs/extra/PubisherClientSnippets.md
@@ -1,0 +1,30 @@
+---
+uid: Google.Pubsub.V1.PublisherClient.ListTopics(System.String,Google.Api.Gax.CallSettings)
+---
+
+Example:
+[!code-cs[](../../snippets/Google.Pubsub.V1.Snippets/PublisherClientSnippets.cs#ListTopics)]
+
+---
+uid: Google.Pubsub.V1.PublisherClient.ListTopicsAsync(System.String,Google.Api.Gax.CallSettings)
+---
+Example:
+[!code-cs[](../../snippets/Google.Pubsub.V1.Snippets/PublisherClientSnippets.cs#ListTopicsAsync)]
+
+---
+uid: Google.Pubsub.V1.PublisherClient.CreateTopic(System.String,Google.Api.Gax.CallSettings)
+---
+Example:
+[!code-cs[](../../snippets/Google.Pubsub.V1.Snippets/PublisherClientSnippets.cs#CreateTopic)]
+
+---
+uid: Google.Pubsub.V1.PublisherClient.CreateTopicAsync(System.String,Google.Api.Gax.CallSettings)
+---
+Example:
+[!code-cs[](../../snippets/Google.Pubsub.V1.Snippets/PublisherClientSnippets.cs#CreateTopicAsync)]
+
+---
+uid: Google.Pubsub.V1.PublisherClient.CreateTopicAsync(System.String,System.Threading.CancellationToken)
+---
+Example:
+[!code-cs[](../../snippets/Google.Pubsub.V1.Snippets/PublisherClientSnippets.cs#CreateTopicAsync)]

--- a/docs/extra/SubscriberClientSnippets.md
+++ b/docs/extra/SubscriberClientSnippets.md
@@ -1,0 +1,30 @@
+---
+uid: Google.Pubsub.V1.SubscriberClient.ListSubscriptions(System.String,Google.Api.Gax.CallSettings)
+---
+
+Example:
+[!code-cs[](../../snippets/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.cs#ListSubscriptions)]
+
+---
+uid: Google.Pubsub.V1.SubscriberClient.ListSubscriptionsAsync(System.String,Google.Api.Gax.CallSettings)
+---
+Example:
+[!code-cs[](../../snippets/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.cs#ListSubscriptionsAsync)]
+
+---
+uid: Google.Pubsub.V1.SubscriberClient.CreateSubscription(System.String,System.String,Google.Pubsub.V1.PushConfig,System.Int32,Google.Api.Gax.CallSettings)
+---
+Example:
+[!code-cs[](../../snippets/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.cs#CreateSubscription)]
+
+---
+uid: Google.Pubsub.V1.SubscriberClient.CreateSubscriptionAsync(System.String,System.String,Google.Pubsub.V1.PushConfig,System.Int32,Google.Api.Gax.CallSettings)
+---
+Example:
+[!code-cs[](../../snippets/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.cs#CreateSubscriptionAsync)]
+
+---
+uid: Google.Pubsub.V1.SubscriberClient.CreateSubscriptionAsync(System.String,System.String,Google.Pubsub.V1.PushConfig,System.Int32,System.Threading.CancellationToken)
+---
+Example:
+[!code-cs[](../../snippets/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.cs#CreateSubscriptionAsync)]

--- a/snippets/Google.Pubsub.V1.Snippets/Google.Pubsub.V1.Snippets.xproj
+++ b/snippets/Google.Pubsub.V1.Snippets/Google.Pubsub.V1.Snippets.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25123" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25123</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>60e5f4c2-7a10-41f1-a247-14c346a8e33a</ProjectGuid>
+    <RootNamespace>Google.Pubsub.V1.Snippets</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/snippets/Google.Pubsub.V1.Snippets/PublisherClientSnippets.cs
+++ b/snippets/Google.Pubsub.V1.Snippets/PublisherClientSnippets.cs
@@ -1,0 +1,75 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Pubsub.V1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class PublisherClientSnippets
+{
+    public void ListTopics()
+    {
+        // <ListTopics>
+        PublisherClient client = PublisherClient.Create();
+        // Alternative: use a known project resource name:
+        // projects/{PROJECT_ID}
+        string projectName = PublisherClient.GetProjectName("PROJECT_ID");
+        foreach (Topic topic in client.ListTopics(projectName))
+        {
+            Console.WriteLine(topic.Name);
+        }
+        // </ListTopics>
+    }
+
+    public async Task ListTopicsAsync()
+    {
+        // <ListTopicsAsync>
+        PublisherClient client = PublisherClient.Create();
+        // Alternative: use a known project resource name:
+        // projects/{PROJECT_ID}
+        string projectName = PublisherClient.GetProjectName("{PROJECT_ID}");
+        IAsyncEnumerable<Topic> topics = client.ListTopicsAsync(projectName);
+        await topics.ForEachAsync(topic =>
+        {
+            Console.WriteLine(topic.Name);
+        });
+        // </ListTopicsAsync>
+    }
+
+    public void CreateTopic()
+    {
+        // <CreateTopic>
+        PublisherClient client = PublisherClient.Create();
+        // Alternative: use a known topic resource name
+        // projects/{PROJECT_ID}/topics/{TOPIC_ID}
+        string topicName = PublisherClient.GetTopicName("{PROJECT_ID}", "{TOPIC_ID}");
+        Topic topic = client.CreateTopic(topicName);
+        Console.WriteLine($"Created {topic.Name}");
+        // </CreateTopic>
+    }
+
+    public async Task CreateTopicAsync()
+    {
+        // <CreateTopicAsync>
+        PublisherClient client = PublisherClient.Create();
+        // Alternative: use a known topic resource name
+        // projects/{PROJECT_ID}/topics/{TOPIC_ID}
+        string topicName = PublisherClient.GetTopicName("{PROJECT_ID}", "{TOPIC_ID}");
+        Topic topic = await client.CreateTopicAsync(topicName);
+        Console.WriteLine($"Created {topic.Name}");
+        // </CreateTopicAsync>
+    }
+}

--- a/snippets/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.cs
+++ b/snippets/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.cs
@@ -1,0 +1,83 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Pubsub.V1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class SubscriberClientSnippets
+{
+    public void ListSubscriptions()
+    {
+        // <ListSubscriptions>
+        SubscriberClient client = SubscriberClient.Create();
+        // Alternative: use a known project resource name:
+        // projects/{PROJECT_ID}
+        string projectName = SubscriberClient.GetProjectName("PROJECT_ID");
+        foreach (Subscription subscription in client.ListSubscriptions(projectName))
+        {
+            Console.WriteLine($"{subscription.Name} subscribed to {subscription.Topic}");
+        }
+        // </ListSubscriptions>
+    }
+
+    public async Task ListSubscriptionsAsync()
+    {
+        // <ListSubscriptionsAsync>
+        SubscriberClient client = SubscriberClient.Create();
+        // Alternative: use a known project resource name:
+        // projects/{PROJECT_ID}
+        string projectName = SubscriberClient.GetProjectName("{PROJECT_ID}");
+        IAsyncEnumerable<Subscription> subscriptions = client.ListSubscriptionsAsync(projectName);
+        await subscriptions.ForEachAsync(subscription =>
+        {
+            Console.WriteLine($"{subscription.Name} subscribed to {subscription.Topic}");
+        });
+        // </ListSubscriptionsAsync>
+    }
+
+    public void CreateSubscription()
+    {
+        // <CreateSubscription>
+        SubscriberClient client = SubscriberClient.Create();
+        // Alternative: use an existing subscription resource name:
+        // projects/{PROJECT_ID}/subscriptions/{SUBSCRIPTION_ID}
+        // Similarly for the topic name:
+        // projects/{PROJECT_ID}/topics/{TOPIC_ID}
+        string subscriptionName = SubscriberClient.GetSubscriptionName("{PROJECT_ID}", "{SUBSCRIPTION_ID}");
+        string topicName = PublisherClient.GetTopicName("{PROJECT_ID}", "{TOPIC_ID}");
+        Subscription subscription = client.CreateSubscription(
+            subscriptionName, topicName, pushConfig: null, ackDeadlineSeconds: 30);
+        Console.WriteLine($"Created {subscription.Name} subscribed to {subscription.Topic}");
+        // </CreateSubscription>
+    }
+
+    public async Task CreateSubscriptionAsync()
+    {
+        // <CreateSubscriptionAsync>
+        SubscriberClient client = SubscriberClient.Create();
+        // Alternative: use an existing subscription resource name:
+        // projects/{PROJECT_ID}/subscriptions/{SUBSCRIPTION_ID}
+        // Similarly for the topic name:
+        // projects/{PROJECT_ID}/topics/{TOPIC_ID}
+        string subscriptionName = SubscriberClient.GetSubscriptionName("{PROJECT_ID}", "{SUBSCRIPTION_ID}");
+        string topicName = PublisherClient.GetTopicName("{PROJECT_ID}", "{TOPIC_ID}");
+        Subscription subscription = await client.CreateSubscriptionAsync(
+            subscriptionName, topicName, pushConfig: null, ackDeadlineSeconds: 30);
+        Console.WriteLine($"Created {subscription.Name} subscribed to {subscription.Topic}");
+        // </CreateSubscriptionAsync>
+    }
+}

--- a/snippets/Google.Pubsub.V1.Snippets/project.json
+++ b/snippets/Google.Pubsub.V1.Snippets/project.json
@@ -1,0 +1,11 @@
+﻿{
+  "description": "Snippets for the Google.Pubsub.V1 package",
+
+  "dependencies": {
+    "Google.Pubsub.V1": ""
+  },
+
+  "frameworks": {
+    "net45": { }
+  }
+}

--- a/snippets/README.md
+++ b/snippets/README.md
@@ -1,0 +1,6 @@
+This directory contains snippet projects.
+Each project relates to an API, and contains source files with
+snippets in, demonstrating how to use the API.
+
+This code is compiled as part of the regular build, but is not
+executed.


### PR DESCRIPTION
This has examples for:
- PublisherClient.ListTopics
- PublisherClient.CreateTopic
- SubscriberClient.ListSubscriptions
- SubscriberClient.CreateSubscription

... and the async equivalents

Still to do:
- Use a genuine "example" section when the docfx template supports it
- Generate the Markdown automatically from the snippet source file (shouldn't be too hard)
- All the other snippets!

To view the results:
- http://jskeet.github.io/gcloud-dotnet/api/Google.Pubsub.V1.PublisherClient.html#Google_Pubsub_V1_PublisherClient_CreateTopic_System_String_Google_Api_Gax_CallSettings_
- http://jskeet.github.io/gcloud-dotnet/api/Google.Pubsub.V1.SubscriberClient.html#Google_Pubsub_V1_SubscriberClient_CreateSubscription_System_String_System_String_Google_Pubsub_V1_PushConfig_System_Int32_Google_Api_Gax_CallSettings_

// cc @rok987 for review

(and look for the other methods)