### PR TITLE
Allow contentType to be null in calls to UploadObject.

### DIFF
--- a/src/Google.Storage.V1/StorageClient.UploadObject.cs
+++ b/src/Google.Storage.V1/StorageClient.UploadObject.cs
@@ -29,7 +29,7 @@ namespace Google.Storage.V1
         /// <param name="bucket">The name of the bucket containing the object. Must not be null.</param>
         /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
         /// <param name="contentType">The content type of the object. This should be a MIME type
-        /// such as "text/html" or "application/octet-stream". Must not be null, but may be empty.</param>
+        /// such as "text/html" or "application/octet-stream". May be null.</param>
         /// <param name="source">The stream to read the data from. Must not be null.</param>
         /// <param name="options">Additional options for the upload. May be null, in which case appropriate
         /// defaults will be used.</param>
@@ -52,7 +52,7 @@ namespace Google.Storage.V1
         /// <param name="bucket">The name of the bucket containing the object. Must not be null.</param>
         /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
         /// <param name="contentType">The content type of the object. This should be a MIME type
-        /// such as "text/html" or "application/octet-stream". Must not be null, but may be empty.</param>
+        /// such as "text/html" or "application/octet-stream". May be null.</param>
         /// <param name="source">The stream to read the data from. Must not be null.</param>
         /// <returns>A task representing the asynchronous operation, with a result returning the
         /// <see cref="Object"/> representation of the uploaded object.</returns>
@@ -67,7 +67,7 @@ namespace Google.Storage.V1
         /// <param name="bucket">The name of the bucket containing the object. Must not be null.</param>
         /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
         /// <param name="contentType">The content type of the object. This should be a MIME type
-        /// such as "text/html" or "application/octet-stream". Must not be null, but may be empty.</param>
+        /// such as "text/html" or "application/octet-stream". May be null.</param>
         /// <param name="source">The stream to read the data from. Must not be null.</param>
         /// <param name="options">Additional options for the upload. May be null, in which case appropriate
         /// defaults will be used.</param>

--- a/src/Google.Storage.V1/StorageClientImpl.UploadObject.cs
+++ b/src/Google.Storage.V1/StorageClientImpl.UploadObject.cs
@@ -34,7 +34,6 @@ namespace Google.Storage.V1
         {
             ValidateBucket(bucket);
             Preconditions.CheckNotNull(objectName, nameof(objectName));
-            Preconditions.CheckNotNull(contentType, nameof(contentType));
             return UploadObject(
                 new Object { Bucket = bucket, Name = objectName, ContentType = contentType },
                 source, options, progress);
@@ -59,7 +58,6 @@ namespace Google.Storage.V1
         {
             ValidateBucket(bucket);
             Preconditions.CheckNotNull(objectName, nameof(objectName));
-            Preconditions.CheckNotNull(contentType, nameof(contentType));
             return UploadObjectAsync(new Object { Bucket = bucket, Name = objectName, ContentType = contentType },
                 source, options, cancellationToken, progress);
         }


### PR DESCRIPTION
Fixes issue #117.

(Note only two implementation changes but three doc changes as one implementation delegates to another.)