### PR TITLE
Treat a null content type as "" when uploading.

### DIFF
--- a/src/Google.Storage.V1/StorageClient.UploadObject.cs
+++ b/src/Google.Storage.V1/StorageClient.UploadObject.cs
@@ -54,21 +54,6 @@ namespace Google.Storage.V1
         /// <param name="contentType">The content type of the object. This should be a MIME type
         /// such as "text/html" or "application/octet-stream". May be null.</param>
         /// <param name="source">The stream to read the data from. Must not be null.</param>
-        /// <returns>A task representing the asynchronous operation, with a result returning the
-        /// <see cref="Object"/> representation of the uploaded object.</returns>
-        public virtual Task<Object> UploadObjectAsync(string bucket, string objectName, string contentType, Stream source)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// Uploads the data for an object in storage asynchronously, from a specified stream.
-        /// </summary>
-        /// <param name="bucket">The name of the bucket containing the object. Must not be null.</param>
-        /// <param name="objectName">The name of the object within the bucket. Must not be null.</param>
-        /// <param name="contentType">The content type of the object. This should be a MIME type
-        /// such as "text/html" or "application/octet-stream". May be null.</param>
-        /// <param name="source">The stream to read the data from. Must not be null.</param>
         /// <param name="options">Additional options for the upload. May be null, in which case appropriate
         /// defaults will be used.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>

--- a/src/Google.Storage.V1/StorageClientImpl.UploadObject.cs
+++ b/src/Google.Storage.V1/StorageClientImpl.UploadObject.cs
@@ -35,17 +35,10 @@ namespace Google.Storage.V1
             ValidateBucket(bucket);
             Preconditions.CheckNotNull(objectName, nameof(objectName));
             return UploadObject(
-                new Object { Bucket = bucket, Name = objectName, ContentType = contentType },
+                new Object { Bucket = bucket, Name = objectName, ContentType = contentType ?? "" },
                 source, options, progress);
-        }
-
-        /// <inheritdoc />
-        public override Task<Object> UploadObjectAsync(string bucket, string objectName, string contentType, Stream source)
-        {
-            return UploadObjectAsync(bucket, objectName, contentType, source,
-                options: null, cancellationToken: CancellationToken.None, progress: null);
-        }
-
+        }        
+        
         /// <inheritdoc />
         public override Task<Object> UploadObjectAsync(
             string bucket,
@@ -58,7 +51,7 @@ namespace Google.Storage.V1
         {
             ValidateBucket(bucket);
             Preconditions.CheckNotNull(objectName, nameof(objectName));
-            return UploadObjectAsync(new Object { Bucket = bucket, Name = objectName, ContentType = contentType },
+            return UploadObjectAsync(new Object { Bucket = bucket, Name = objectName, ContentType = contentType ?? "" },
                 source, options, cancellationToken, progress);
         }
 
@@ -70,7 +63,6 @@ namespace Google.Storage.V1
             IProgress<IUploadProgress> progress = null)
         {
             ValidateObject(destination, nameof(destination));
-            Preconditions.CheckArgument(destination.ContentType != null, nameof(destination), "Object must have a ContentType");
             Preconditions.CheckNotNull(source, nameof(source));
             var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
             options?.ModifyMediaUpload(mediaUpload);
@@ -95,7 +87,6 @@ namespace Google.Storage.V1
             IProgress<IUploadProgress> progress = null)
         {
             ValidateObject(destination, nameof(destination));
-            Preconditions.CheckArgument(destination.ContentType != null, nameof(destination), "Object must have a ContentType");
             Preconditions.CheckNotNull(source, nameof(source));
             var mediaUpload = Service.Objects.Insert(destination, destination.Bucket, source, destination.ContentType);
             options?.ModifyMediaUpload(mediaUpload);

--- a/test/Google.Storage.V1.IntegrationTests/UploadObjectTest.cs
+++ b/test/Google.Storage.V1.IntegrationTests/UploadObjectTest.cs
@@ -212,6 +212,12 @@ namespace Google.Storage.V1.IntegrationTests
                 null));
         }
 
+        [Fact]
+        public void UploadObject_NullContentType()
+        {
+            s_config.Client.UploadObject(s_bucket, GenerateName(), null, new MemoryStream());
+        }
+
         private Object GetExistingObject()
         {
             var obj = s_config.Client.UploadObject(s_bucket, GenerateName(), "application/octet-stream", GenerateData(100));


### PR DESCRIPTION
We need to manually coalesce this, as the resumable upload code requires a
content type to be specified, but allows it to be empty.

This also removes an overload of UploadObjectAsync which was unnecessary -
no doubt overlooked when we introduced optional parameters.

Fixes issue #117.