### PR TITLE
Fix Datastore RunQuery snippets by improving tool chain

### DIFF
--- a/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreClientSnippets.cs
+++ b/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreClientSnippets.cs
@@ -65,7 +65,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             PartitionId partitionId = _fixture.PartitionId;
             string kind = _fixture.BookKind;
 
-            // <RunQuery>
+            // <RunQuery_System.String__Google.Datastore.V1Beta3.PartitionId__Google.Datastore.V1Beta3.ReadOptions__Google.Datastore.V1Beta3.Query>
             DatastoreClient client = DatastoreClient.Create();
             Query query = new Query
             {
@@ -91,7 +91,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             {
                 Console.WriteLine(result.Entity);
             }
-            // </RunQuery>
+            // </RunQuery_System.String__Google.Datastore.V1Beta3.PartitionId__Google.Datastore.V1Beta3.ReadOptions__Google.Datastore.V1Beta3.Query>
 
             Assert.Equal(1, response.Batch.EntityResults.Count);
             Entity entity = response.Batch.EntityResults[0].Entity;
@@ -106,7 +106,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             PartitionId partitionId = _fixture.PartitionId;
             string kind = _fixture.BookKind;
 
-            // <RunQuery>
+            // <RunQuery_System.String__Google.Datastore.V1Beta3.PartitionId__Google.Datastore.V1Beta3.ReadOptions__Google.Datastore.V1Beta3.GqlQuery>
             DatastoreClient client = DatastoreClient.Create();
             GqlQuery gqlQuery = new GqlQuery
             {
@@ -123,7 +123,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             {
                 Console.WriteLine(result.Entity);
             }
-            // </RunQuery>
+            // </RunQuery_System.String__Google.Datastore.V1Beta3.PartitionId__Google.Datastore.V1Beta3.ReadOptions__Google.Datastore.V1Beta3.GqlQuery>
 
             Assert.Equal(1, response.Batch.EntityResults.Count);
             Entity entity = response.Batch.EntityResults[0].Entity;

--- a/tools/Google.GCloud.Tools.GenerateSnippetMarkdown/Program.cs
+++ b/tools/Google.GCloud.Tools.GenerateSnippetMarkdown/Program.cs
@@ -113,8 +113,8 @@ namespace Google.GCloud.Tools.GenerateSnippetMarkdown
             // We want to use prefix matching for overload resolution, as well as avoiding false-positives
             // due to short names. So two situations:
             // <Foo> - match project.client.Foo(
-            // <Foo_Bar> - match project.client.Foo(Bar
-            string methodStart = snippetName.Contains("_") ? snippetName.Replace("_", "(") : snippetName + "(";
+            // <Foo_Bar__Baz> - match project.client.Foo(Bar,Baz
+            string methodStart = snippetName.Contains("_") ? snippetName.Replace("__", ",").Replace("_", "(") : snippetName + "(";
             return uid.StartsWith($"{projectName}.{clientName}.{methodStart}");
         }
 


### PR DESCRIPTION
Now in our overload resolution, we replace __ by , when matching UID...
unfortunately we're very limited in what can appear in a snippet name.
(We may well want to revisit all of this at some point...)