### PR TITLE
Stop coalescing null to "" for the content type

### DIFF
--- a/src/Google.Storage.V1/StorageClientImpl.UploadObject.cs
+++ b/src/Google.Storage.V1/StorageClientImpl.UploadObject.cs
@@ -35,7 +35,7 @@ namespace Google.Storage.V1
             ValidateBucketName(bucket);
             Preconditions.CheckNotNull(objectName, nameof(objectName));
             return UploadObject(
-                new Object { Bucket = bucket, Name = objectName, ContentType = contentType ?? "" },
+                new Object { Bucket = bucket, Name = objectName, ContentType = contentType },
                 source, options, progress);
         }        
         
@@ -51,7 +51,7 @@ namespace Google.Storage.V1
         {
             ValidateBucketName(bucket);
             Preconditions.CheckNotNull(objectName, nameof(objectName));
-            return UploadObjectAsync(new Object { Bucket = bucket, Name = objectName, ContentType = contentType ?? "" },
+            return UploadObjectAsync(new Object { Bucket = bucket, Name = objectName, ContentType = contentType },
                 source, options, cancellationToken, progress);
         }
 


### PR DESCRIPTION
This was previously required due to a limitation in the REST library;
now we've updated to 1.13 we can just let the null propagate.