### PR TITLE
Prototype of REST API page streaming.

### DIFF
--- a/GoogleApis.sln
+++ b/GoogleApis.sln
@@ -53,6 +53,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Bigquery.V2.CleanTes
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Bigquery.V2.Tests", "test\Google.Bigquery.V2.Tests\Google.Bigquery.V2.Tests.xproj", "{96BDCC84-EF76-4B35-A390-D2F6D7B8F55B}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Google.Apis.PageStreaming", "src\Google.Apis.PageStreaming\Google.Apis.PageStreaming.xproj", "{5E91D6AC-6BC4-4AA2-8FAC-C6F94FBC4F5F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -127,6 +129,10 @@ Global
 		{96BDCC84-EF76-4B35-A390-D2F6D7B8F55B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{96BDCC84-EF76-4B35-A390-D2F6D7B8F55B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{96BDCC84-EF76-4B35-A390-D2F6D7B8F55B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E91D6AC-6BC4-4AA2-8FAC-C6F94FBC4F5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E91D6AC-6BC4-4AA2-8FAC-C6F94FBC4F5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E91D6AC-6BC4-4AA2-8FAC-C6F94FBC4F5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E91D6AC-6BC4-4AA2-8FAC-C6F94FBC4F5F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -149,5 +155,6 @@ Global
 		{A55F5009-37C2-4EB6-A100-AB86885A3AE9} = {F638F51C-C1C3-449B-ADAE-8196073649A5}
 		{B5F7491C-ED9E-4032-88C0-22EE959D19E8} = {95457640-F06C-4390-9CCD-EDFECD772588}
 		{96BDCC84-EF76-4B35-A390-D2F6D7B8F55B} = {F87E02E7-3142-4439-8938-42DD79337135}
+		{5E91D6AC-6BC4-4AA2-8FAC-C6F94FBC4F5F} = {AC0CC83C-0448-419E-914E-E63036A77BD9}
 	EndGlobalSection
 EndGlobal

--- a/snippets/Google.Storage.V1.Snippets/StorageClientSnippets.cs
+++ b/snippets/Google.Storage.V1.Snippets/StorageClientSnippets.cs
@@ -51,7 +51,7 @@ namespace Google.Storage.V1.Snippets
             var obj2 = client.UploadObject(bucketName, "folder1/file2.txt", "text/plain", new MemoryStream(content));
 
             // List objects
-            foreach (var obj in client.ListObjects(bucketName, ""))
+            foreach (var obj in client.ListObjectsPageStream(bucketName, "").Flatten())
             {
                 Console.WriteLine(obj.Name);
             }
@@ -67,9 +67,9 @@ namespace Google.Storage.V1.Snippets
             _fixture.RegisterBucketToDelete(bucketName);
 
             Assert.Equal(content, File.ReadAllBytes("file1.txt"));
-            Assert.Contains(client.ListObjects(bucketName, ""), o => o.Name == "file1.txt");
-            Assert.Contains(client.ListObjects(bucketName, ""), o => o.Name == "folder1/file2.txt");
-            Assert.Contains(client.ListBuckets(projectId), b => b.Name == bucketName);
+            Assert.Contains(client.ListObjectsPageStream(bucketName, "").Flatten(), o => o.Name == "file1.txt");
+            Assert.Contains(client.ListObjectsPageStream(bucketName, "").Flatten(), o => o.Name == "folder1/file2.txt");
+            Assert.Contains(client.ListBucketsPageStream(projectId).Flatten(), b => b.Name == bucketName);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace Google.Storage.V1.Snippets
             var client = StorageClient.Create();
 
             // List all buckets associated with a project
-            var buckets = client.ListBuckets(projectId);
+            var buckets = client.ListBucketsPageStream(projectId).Flatten();
             // End snippet
 
             Assert.Contains(buckets, b => _fixture.BucketName == b.Name);
@@ -178,7 +178,7 @@ namespace Google.Storage.V1.Snippets
             var client = StorageClient.Create();
 
             // List only objects with a name starting with "greet"
-            var objects = client.ListObjects(bucketName, "greet");
+            var objects = client.ListObjectsPageStream(bucketName, "greet").Flatten();
             // End snippet
 
             Assert.Contains(objects, o => _fixture.HelloStorageObjectName == o.Name);
@@ -414,7 +414,7 @@ namespace Google.Storage.V1.Snippets
             // want to make sure it matches the one in the test
             Assert.Equal(objectName, tempObjectName);
 
-            Assert.DoesNotContain(client.ListObjects(bucketName, ""), o => o.Name == objectName);
+            Assert.DoesNotContain(client.ListObjectsPageStream(bucketName, "").Flatten(), o => o.Name == objectName);
         }
 
         [Fact]
@@ -429,7 +429,7 @@ namespace Google.Storage.V1.Snippets
             client.DeleteBucket(bucketName);
             // End snippet
 
-            Assert.DoesNotContain(client.ListBuckets(_fixture.ProjectId), b => b.Name == bucketName);
+            Assert.DoesNotContain(client.ListBucketsPageStream(_fixture.ProjectId).Flatten(), b => b.Name == bucketName);
         }
     }
 }

--- a/snippets/Google.Storage.V1.Snippets/StorageSnippetFixture.cs
+++ b/snippets/Google.Storage.V1.Snippets/StorageSnippetFixture.cs
@@ -85,7 +85,7 @@ namespace Google.Storage.V1.Snippets
             var client = StorageClient.Create();
             foreach (var bucket in bucketsToDelete)
             {
-                foreach (var obj in client.ListObjects(bucket, null, new ListObjectsOptions { Versions = true }).ToList())
+                foreach (var obj in client.ListObjectsPageStream(bucket, null, new ListObjectsOptions { Versions = true }).Flatten().ToList())
                 {
                     client.DeleteObject(obj, new DeleteObjectOptions { Generation = obj.Generation });
                 }

--- a/src/Google.Apis.PageStreaming/FixedSizePage.cs
+++ b/src/Google.Apis.PageStreaming/FixedSizePage.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Google.Apis.PageStreaming
+{
+    public sealed class FixedSizePage<TResource> : IEnumerable<TResource>
+    {
+        private readonly IEnumerable<TResource> _resources;
+        public string NextPageToken { get; }
+
+        public FixedSizePage(IEnumerable<TResource> resources, string nextPageToken)
+        {
+            _resources = resources;
+            NextPageToken = nextPageToken;
+        }
+
+        public IEnumerator<TResource> GetEnumerator() => _resources.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/Google.Apis.PageStreaming/Google.Apis.PageStreaming.xproj
+++ b/src/Google.Apis.PageStreaming/Google.Apis.PageStreaming.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25123" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25123</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>5e91d6ac-6bc4-4aa2-8fac-c6f94fbc4f5f</ProjectGuid>
+    <RootNamespace>Google.Apis.PageStreaming</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Google.Apis.PageStreaming/IPageManager.cs
+++ b/src/Google.Apis.PageStreaming/IPageManager.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Apis.PageStreaming
+{
+    /// <summary>
+    /// Extension methods on IPageManager, just to avoid repetitive code.
+    /// </summary>
+    internal static class PageManagerExtensions
+    {
+        internal static IEnumerable<TResource> GetResourcesEmptyIfNull<TRequest, TResponse, TResource>(
+            this IPageManager<TRequest, TResponse, TResource> manager, TResponse response) =>
+            manager.GetResources(response) ?? Enumerable.Empty<TResource>();
+    }
+
+    public interface IPageManager<TRequest, TResponse, TResource>
+    {
+        void SetPageSize(TRequest request, int pageSize);
+        void SetPageToken(TRequest request, string pageToken);
+        IEnumerable<TResource> GetResources(TResponse response);
+        string GetNextPageToken(TResponse response);
+    }
+}

--- a/src/Google.Apis.PageStreaming/PageStreamingInterfaces.cs
+++ b/src/Google.Apis.PageStreaming/PageStreamingInterfaces.cs
@@ -1,0 +1,92 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.PageStreaming
+{
+    public interface IPagedAsyncEnumerable<T> : IAsyncEnumerable<T>
+    {
+        new IPagedAsyncEnumerator<T> GetEnumerator();
+    }
+
+    public interface IPagedAsyncEnumerable<TResponse, TResource> : IPagedAsyncEnumerable<TResponse>
+    {
+        /// <summary>
+        /// Flattens this asynchronous sequence of "pages of resources" to an asynchronous sequence of resources.
+        /// </summary>
+        /// <remarks>
+        /// This is expected to be equivalent to calling <c>SelectMany(page => page.ToAsyncEnumerable())</c>, and could
+        /// be implemented as an extension method, but is part of the interface to provide greater discoverability.
+        /// </remarks>
+        /// <returns>A sequence of resources.</returns>
+        IAsyncEnumerable<TResource> Flatten();
+
+        /// <summary>
+        /// Returns an asynchronous sequence of fixed-size pages, so that only the final page returned can have fewer items than
+        /// <paramref name="pageSize"/>. API requests are made appropriately to ensure that the page token returned at
+        /// the end of each page reflects exactly that page boundary; this may entail more API requests than iterating
+        /// over the sequence without enforcing fixed page sizes.
+        /// </summary>
+        /// <param name="pageSize">The size of the pages to return. Must be positive.</param>
+        /// <remarks>
+        /// This could be implemented as an extension method, but is part of the interface to provide greater discoverability.
+        /// </remarks>
+        /// <returns>A sequence of fixed-size pages.</returns>
+        IAsyncEnumerable<FixedSizePage<TResource>> WithFixedPageSize(int pageSize);
+    }
+
+    public interface IPagedAsyncEnumerator<T> : IAsyncEnumerator<T>
+    {
+        Task<bool> MoveNext(int pageSize, CancellationToken cancellationToken);
+    }
+
+    public interface IPagedEnumerable<T> : IEnumerable<T>
+    {
+        new IPagedEnumerator<T> GetEnumerator();
+    }
+
+    public interface IPagedEnumerable<TResponse, TResource> : IPagedEnumerable<TResponse>
+    {
+        /// <summary>
+        /// Flattens this sequence of "pages of resources" to a sequence of resources.
+        /// </summary>
+        /// <remarks>
+        /// This is expected to be equivalent to calling <c>SelectMany(page => page)</c>, and could
+        /// be implemented as an extension method, but is part of the interface to provide greater discoverability.
+        /// </remarks>
+        /// <returns>A sequence of resources.</returns>
+        IEnumerable<TResource> Flatten();
+
+        /// <summary>
+        /// Returns a sequence of fixed-size pages, so that only the final page returned can have fewer items than
+        /// <paramref name="pageSize"/>. API requests are made appropriately to ensure that the page token returned at
+        /// the end of each page reflects exactly that page boundary; this may entail more API requests than iterating
+        /// over the sequence without enforcing fixed page sizes.
+        /// </summary>
+        /// <param name="pageSize">The size of the pages to return. Must be positive.</param>
+        /// <remarks>
+        /// This could be implemented as an extension method, but is part of the interface to provide greater discoverability.
+        /// </remarks>
+        /// <returns>A sequence of fixed-size pages.</returns>
+        IEnumerable<FixedSizePage<TResource>> WithFixedPageSize(int pageSize);
+    }
+
+    public interface IPagedEnumerator<T> : IEnumerator<T>
+    {
+        bool MoveNext(int pageSize);
+    }
+}

--- a/src/Google.Apis.PageStreaming/PagedAsyncEnumerable.cs
+++ b/src/Google.Apis.PageStreaming/PagedAsyncEnumerable.cs
@@ -1,0 +1,165 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Requests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.PageStreaming
+{
+    public sealed class PagedAsyncEnumerable<TRequest, TResponse, TResource> : IPagedAsyncEnumerable<TResponse, TResource>
+        where TRequest : class, IClientServiceRequest<TResponse>
+        where TResponse : class
+    {
+        private readonly Func<TRequest> _requestProvider;
+        private readonly IPageManager<TRequest, TResponse, TResource> _pageManager;
+
+        public PagedAsyncEnumerable(Func<TRequest> requestProvider,
+            IPageManager<TRequest, TResponse, TResource> pageManager)
+        {
+            _requestProvider = Preconditions.CheckNotNull(requestProvider, nameof(requestProvider));
+            _pageManager = Preconditions.CheckNotNull(pageManager, nameof(pageManager));
+        }
+
+        public IPagedAsyncEnumerator<TResponse> GetEnumerator() => new PagedAsyncEnumerator(_requestProvider(), _pageManager);
+
+        IAsyncEnumerator<TResponse> IAsyncEnumerable<TResponse>.GetEnumerator() => GetEnumerator();
+
+        /// <inheritdoc />
+        public IAsyncEnumerable<TResource> Flatten() => this.SelectMany(page => _pageManager.GetResourcesEmptyIfNull(page).ToAsyncEnumerable());
+
+        /// <inheritdoc />
+        public IAsyncEnumerable<FixedSizePage<TResource>> WithFixedPageSize(int pageSize) =>
+            new FixedPageSizeAsyncEnumerable(this, _pageManager, pageSize);
+
+        private class PagedAsyncEnumerator : IPagedAsyncEnumerator<TResponse>
+        {
+            private readonly TRequest _request; // This is mutated during iteration
+            private readonly IPageManager<TRequest, TResponse, TResource> _pageManager;
+            private bool _finished;
+
+            public PagedAsyncEnumerator(TRequest request, IPageManager<TRequest, TResponse, TResource> pageManager)
+            {
+                _request = request;
+                _pageManager = pageManager;
+            }
+
+            public TResponse Current { get; private set; }
+
+            public async Task<bool> MoveNext(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (_finished)
+                {
+                    return false;
+                }
+                Current = await _request.ExecuteAsync(cancellationToken);
+                var nextPageToken = _pageManager.GetNextPageToken(Current);
+                if (nextPageToken == null)
+                {
+                    _finished = true;
+                }
+                // Prepare the next request...
+                _pageManager.SetPageToken(_request, nextPageToken);
+                return true;
+            }
+
+            public Task<bool> MoveNext(int pageSize, CancellationToken cancellationToken)
+            {
+                _pageManager.SetPageSize(_request, pageSize);
+                return MoveNext(cancellationToken);
+            }
+
+            public void Dispose() { }
+        }
+
+        private class FixedPageSizeAsyncEnumerable : IAsyncEnumerable<FixedSizePage<TResource>>
+        {
+            private readonly IPagedAsyncEnumerable<TResponse, TResource> _source;
+            private readonly int _pageSize;
+            private readonly IPageManager<TRequest, TResponse, TResource> _pageManager;
+
+            internal FixedPageSizeAsyncEnumerable(
+                IPagedAsyncEnumerable<TResponse, TResource> source,
+                IPageManager<TRequest, TResponse, TResource> pageManager,
+                int pageSize)
+            {
+                _source = source;
+                _pageManager = pageManager;
+                _pageSize = pageSize;
+            }
+
+            public IAsyncEnumerator<FixedSizePage<TResource>> GetEnumerator() =>
+                new Enumerator(_source.GetEnumerator(), _pageManager, _pageSize);
+
+            private class Enumerator : IAsyncEnumerator<FixedSizePage<TResource>>
+            {
+                private readonly IPagedAsyncEnumerator<TResponse> _enumerator;
+                private readonly int _pageSize;
+                private readonly IPageManager<TRequest, TResponse, TResource> _pageManager;
+
+                internal Enumerator(
+                    IPagedAsyncEnumerator<TResponse> enumerator,
+                    IPageManager<TRequest, TResponse, TResource> pageManager,
+                    int pageSize)
+                {
+                    _enumerator = enumerator;
+                    _pageManager = pageManager;
+                    _pageSize = pageSize;
+                }
+
+                public FixedSizePage<TResource> Current { get; private set; }
+
+                public async Task<bool> MoveNext(CancellationToken cancellationToken)
+                {
+                    var items = new List<TResource>(_pageSize);
+                    while (items.Count < _pageSize)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        int requestCount = _pageSize - items.Count;
+                        var done = !(await _enumerator.MoveNext(requestCount, cancellationToken).ConfigureAwait(false));
+                        if (done)
+                        {
+                            break;
+                        }
+                        var resources = _pageManager.GetResourcesEmptyIfNull(_enumerator.Current);
+                        items.AddRange(resources);
+                        if (items.Count > _pageSize)
+                        {
+                            // TODO: B  etter exception type?
+                            throw new NotSupportedException("Invalid server response: " +
+                                $"requested {requestCount} items, received {resources.Count()} items");
+                        }
+                    }
+                    if (items.Count != 0)
+                    {
+                        Current = new FixedSizePage<TResource>(items, _pageManager.GetNextPageToken(_enumerator.Current));
+                        return true;
+                    }
+                    Current = null;
+                    return false;
+                }
+
+                public void Dispose()
+                {
+                    _enumerator.Dispose();
+                }
+            }
+        }
+
+    }
+}

--- a/src/Google.Apis.PageStreaming/PagedEnumerable.cs
+++ b/src/Google.Apis.PageStreaming/PagedEnumerable.cs
@@ -1,0 +1,126 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Requests;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Apis.PageStreaming
+{
+    public sealed class PagedEnumerable<TRequest, TResponse, TResource> : IPagedEnumerable<TResponse, TResource>
+        where TRequest : class, IClientServiceRequest<TResponse>
+        where TResponse : class
+    {
+        private readonly Func<TRequest> _requestProvider;
+        private readonly IPageManager<TRequest, TResponse, TResource> _pageManager;
+
+        public PagedEnumerable(Func<TRequest> requestProvider,
+            IPageManager<TRequest, TResponse, TResource> pageManager)
+        {
+            _requestProvider = Preconditions.CheckNotNull(requestProvider, nameof(requestProvider));
+            _pageManager = Preconditions.CheckNotNull(pageManager, nameof(pageManager));
+        }
+
+        public IPagedEnumerator<TResponse> GetEnumerator() => new PagedEnumerator(_requestProvider(), _pageManager);
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator<TResponse> IEnumerable<TResponse>.GetEnumerator() => GetEnumerator();
+
+        /// <inheritdoc />
+        public IEnumerable<TResource> Flatten() => this.SelectMany(page => _pageManager.GetResourcesEmptyIfNull(page));
+
+        /// <inheritdoc />
+        public IEnumerable<FixedSizePage<TResource>> WithFixedPageSize(int pageSize)
+        {
+            Preconditions.CheckArgument(pageSize > 0, nameof(pageSize), "Must be greater than 0");
+            using (var enumerator = GetEnumerator())
+            {
+                bool done = false;
+                while (!done)
+                {
+                    var items = new List<TResource>(pageSize);
+                    while (items.Count < pageSize)
+                    {
+                        int requestCount = pageSize - items.Count;
+                        done = !enumerator.MoveNext(requestCount);
+                        if (done)
+                        {
+                            break;
+                        }
+                        var resources = _pageManager.GetResourcesEmptyIfNull(enumerator.Current);
+                        items.AddRange(resources);
+                        if (items.Count > pageSize)
+                        {
+                            throw new NotSupportedException("Invalid server response: " +
+                                $"requested {requestCount} items, received {resources.Count()} items");
+                        }
+                    }
+                    if (items.Count != 0)
+                    {
+                        yield return new FixedSizePage<TResource>(items, _pageManager.GetNextPageToken(enumerator.Current));
+                    }
+                }
+            }
+        }
+
+        private class PagedEnumerator : IPagedEnumerator<TResponse>
+        {
+            private readonly TRequest _request; // This is mutated during iteration
+            private readonly IPageManager<TRequest, TResponse, TResource> _pageManager;
+            private bool _finished;
+
+            public PagedEnumerator(TRequest request, IPageManager<TRequest, TResponse, TResource> pageManager)
+            {
+                _request = request;
+                _pageManager = pageManager;
+            }
+
+            public TResponse Current { get; private set; }
+
+            object IEnumerator.Current => Current;
+
+            public bool MoveNext()
+            {
+                if (_finished)
+                {
+                    return false;
+                }
+                Current = _request.Execute();
+                var nextPageToken = _pageManager.GetNextPageToken(Current);
+                if (nextPageToken == null)
+                {
+                    _finished = true;
+                }
+                // Prepare the next request...
+                _pageManager.SetPageToken(_request, nextPageToken);
+                return true;
+            }
+
+            public bool MoveNext(int pageSize)
+            {
+                _pageManager.SetPageSize(_request, pageSize);
+                return MoveNext();
+            }
+
+            public void Reset()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/Google.Apis.PageStreaming/Preconditions.cs
+++ b/src/Google.Apis.PageStreaming/Preconditions.cs
@@ -1,0 +1,175 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+// Note: we'd really like to have a Google.Common package, but at the moment
+// it would only contain Preconditions, which seems a small benefit for the cost
+// of a dependency (and repo). Until then, this class will be copied and pasted in various
+// places. Where it needs to be public, it should be given a project-specific name; where it
+// can be entirely internal, we can leave it as "Preconditions".
+
+namespace Google.Apis.PageStreaming
+{
+    /// <summary>
+    /// Preconditions for checking method arguments, state etc.
+    /// </summary>
+    internal static class Preconditions
+    {
+        /// <summary>
+        /// Checks that the given argument (to the calling method) is non-null.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="argument"></param>
+        /// <param name="paramName">The name of the parameter in the calling method.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="argument"/> is null</exception>
+        /// <returns><paramref name="argument"/> if it is not null</returns>
+        internal static T CheckNotNull<T>(T argument, string paramName) where T : class
+        {
+            if (argument == null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+            return argument;
+        }
+
+        /// <summary>
+        /// Checks that the given argument value is valid.
+        /// </summary>
+        /// <remarks>
+        /// Note that the upper bound (<paramref name="maxInclusive"/>) is inclusive,
+        /// not exclusive. This is deliberate, to allow the specification of ranges which include
+        /// <see cref="Int32.MaxValue"/>.
+        /// </remarks>
+        /// <param name="argument">The value of the argument passed to the calling method.</param>
+        /// <param name="paramName">The name of the parameter in the calling method.</param>
+        /// <param name="minInclusive">The smallest valid value.</param>
+        /// <param name="maxInclusive">The largest valid value.</param>
+        /// <returns><paramref name="argument"/> if it was in range</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The argument was outside the specified range.</exception>
+        internal static int CheckArgumentRange(int argument, string paramName, int minInclusive, int maxInclusive)
+        {
+            if (argument < minInclusive || argument > maxInclusive)
+            {
+                throw new ArgumentOutOfRangeException(
+                    paramName,
+                    $"Value {argument} should be in range [{minInclusive}, {maxInclusive}]");
+            }
+            return argument;
+        }
+
+        /// <summary>
+        /// Checks that given condition is met, throwing an <see cref="InvalidOperationException"/> otherwise.
+        /// </summary>
+        /// <param name="condition">The (already evaluated) condition to check.</param>
+        /// <param name="message">The message to include in the exception, if generated. This should not
+        /// use interpolation, as the interpolation would be performed regardless of whether or
+        /// not an exception is thrown.</param>
+        internal static void CheckState(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+
+        /// <summary>
+        /// Checks that given condition is met, throwing an <see cref="InvalidOperationException"/> otherwise.
+        /// </summary>
+        /// <param name="condition">The (already evaluated) condition to check.</param>
+        /// <param name="format">The format string to use to create the exception message if the
+        /// condition is not met.</param>
+        /// <param name="arg0">The argument to the format string.</param>
+        internal static void CheckState<T>(bool condition, string format, T arg0)
+        {
+            if (!condition)
+            {
+                throw new InvalidOperationException(string.Format(format, arg0));
+            }
+        }
+
+        /// <summary>
+        /// Checks that given condition is met, throwing an <see cref="InvalidOperationException"/> otherwise.
+        /// </summary>
+        /// <param name="condition">The (already evaluated) condition to check.</param>
+        /// <param name="format">The format string to use to create the exception message if the
+        /// condition is not met.</param>
+        /// <param name="arg0">The first argument to the format string.</param>
+        /// <param name="arg1">The second argument to the format string.</param>
+        internal static void CheckState<T1, T2>(bool condition, string format, T1 arg0, T2 arg1)
+        {
+            if (!condition)
+            {
+                throw new InvalidOperationException(string.Format(format, arg0, arg1));
+            }
+        }
+
+
+        /// <summary>
+        /// Checks that given argument-based condition is met, throwing an <see cref="ArgumentException"/> otherwise.
+        /// </summary>
+        /// <param name="condition">The (already evaluated) condition to check.</param>
+        /// <param name="paramName">The name of the parameter whose value is being tested.</param>
+        /// <param name="message">The message to include in the exception, if generated. This should not
+        /// use interpolation, as the interpolation would be performed regardless of whether or not an exception
+        /// is thrown.</param>
+        internal static void CheckArgument(bool condition, string paramName, string message)
+        {
+            if (!condition)
+            {
+                throw new ArgumentException(message, paramName);
+            }
+        }
+
+        /// <summary>
+        /// Checks that given argument-based condition is met, throwing an <see cref="ArgumentException"/> otherwise.
+        /// </summary>
+        /// <param name="condition">The (already evaluated) condition to check.</param>
+        /// <param name="paramName">The name of the parameter whose value is being tested.</param>
+        /// <param name="format">The format string to use to create the exception message if the
+        /// condition is not met.</param>
+        /// <param name="arg0">The argument to the format string.</param>
+        internal static void CheckArgument<T>(bool condition, string paramName, string format, T arg0)
+        {
+            if (!condition)
+            {
+                throw new ArgumentException(string.Format(format, arg0), paramName);
+            }
+        }
+
+        /// <summary>
+        /// Checks that given argument-based condition is met, throwing an <see cref="ArgumentException"/> otherwise.
+        /// </summary>
+        /// <param name="condition">The (already evaluated) condition to check.</param>
+        /// <param name="paramName">The name of the parameter whose value is being tested.</param>
+        /// <param name="format">The format string to use to create the exception message if the
+        /// condition is not met.</param>
+        /// <param name="arg0">The first argument to the format string.</param>
+        /// <param name="arg1">The second argument to the format string.</param>
+        internal static void CheckArgument<T1, T2>(bool condition, string paramName, string format, T1 arg0, T2 arg1)
+        {
+            if (!condition)
+            {
+                throw new ArgumentException(string.Format(format, arg0, arg1), paramName);
+            }
+        }
+
+        internal static T CheckEnumValue<T>(T value, string paramName) where T : struct
+        {
+            CheckArgument(Enum.IsDefined(typeof(T), value), paramName,
+                "Value {0} not defined in enum {1}", value, typeof(T).Name);
+            return value;
+        }
+    }
+}

--- a/src/Google.Apis.PageStreaming/project.json
+++ b/src/Google.Apis.PageStreaming/project.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0-*",
-  "summary": "Wrapper library for Google.Apis.Storage.v1",
-  "description": "Wrapper library for Google.Apis.Storage.v1, making common operations simpler in client code.",
+  "summary": "Advanced page streaming support for REST APIs",
+  "description": "Advanced page streaming support for REST APIs.",
   "authors": [ "Google Inc." ],
   "owners": [ "google-apis-packages" ],
   "tags": [ "Google" ],
@@ -16,10 +16,8 @@
 
   "dependencies": {
     "Google.Apis": "1.13.0",
-    "Google.Apis.Auth": "1.13.0",
     "Google.Apis.Core": "1.13.0",
-    "Google.Apis.Storage.v1": "1.13.0.482",
-    "Google.Apis.PageStreaming": ""
+    "Ix-Async": "1.2.5"
   },
   "frameworks": {
     "net45": {

--- a/src/Google.Storage.V1/StorageClient.ListBuckets.cs
+++ b/src/Google.Storage.V1/StorageClient.ListBuckets.cs
@@ -12,33 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.PageStreaming;
 using Google.Apis.Storage.v1.Data;
 using System;
-using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Google.Storage.V1
 {
     // ListBuckets methods on StorageClient
     public abstract partial class StorageClient
-    {        
+    {
         /// <summary>
-        /// Asynchronously lists the buckets in a given project, returning the results as a list.
+        /// Asynchronously lists the buckets in a given project.
         /// </summary>
-        /// <remarks>
-        /// This lists all the buckets within a project before the returned task completes.
-        /// This does not support reporting progress, or streaming the results.
-        /// </remarks>
         /// <param name="projectId">The ID of the project to list the buckets from. Must not be null.</param>
         /// <param name="options">The options for the operation. May be null, in which case
         /// defaults will be supplied.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A list of buckets within the project.</returns>
-        public virtual Task<IList<Bucket>> ListAllBucketsAsync(
+        /// <returns>An asynchronous sequence of pages of buckets.</returns>
+        public virtual IPagedAsyncEnumerable<Buckets, Bucket> ListBucketsPageStreamAsync(
             string projectId,
-            ListBucketsOptions options = null,
-            CancellationToken cancellationToken = default(CancellationToken))
+            ListBucketsOptions options = null)
         {
             throw new NotImplementedException();
         }
@@ -55,7 +48,7 @@ namespace Google.Storage.V1
         /// <param name="options">The options for the operation. May be null, in which case
         /// defaults will be supplied.</param>
         /// <returns>A sequence of buckets within the project.</returns>
-        public virtual IEnumerable<Bucket> ListBuckets(string projectId, ListBucketsOptions options = null)
+        public virtual IPagedEnumerable<Buckets, Bucket> ListBucketsPageStream(string projectId, ListBucketsOptions options = null)
         {
             throw new NotImplementedException();
         }

--- a/src/Google.Storage.V1/StorageClient.ListObjects.cs
+++ b/src/Google.Storage.V1/StorageClient.ListObjects.cs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.PageStreaming;
+using Google.Apis.Storage.v1.Data;
 using System;
-using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Storage.V1
@@ -24,30 +24,24 @@ namespace Google.Storage.V1
     public abstract partial class StorageClient
     {
         /// <summary>
-        /// Asynchronously lists the objects in a given bucket, returning the results as a list.
+        /// Asynchronously lists the objects in a given bucket.
         /// </summary>
-        /// <remarks>
-        /// This lists the objects within a bucket before the returned task completes.
-        /// This does not support reporting progress, or streaming the results.
-        /// </remarks>
         /// <param name="bucket">The bucket to list the objects from. Must not be null.</param>
         /// <param name="prefix">The prefix to match. Only objects with names that start with this string will be returned.
         /// This parameter may be null, in which case no filtering is performed.</param>
         /// <param name="options">The options for the operation. May be null, in which case
         /// defaults will be supplied.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A list of objects within the bucket.</returns>
-        public virtual Task<IList<Object>> ListAllObjectsAsync(
+        /// <returns>An asynchronous sequence of pages of objects in the specified bucket.</returns>
+        public virtual IPagedAsyncEnumerable<Objects, Object> ListObjectsPageStreamAsync(
             string bucket,
             string prefix,
-            ListObjectsOptions options = null,
-            CancellationToken cancellationToken = default(CancellationToken))
+            ListObjectsOptions options = null)
         {
             throw new NotImplementedException();
         }
 
         /// <summary>
-        /// Lists the objects in a given bucket, synchronously but lazily.
+        /// Synchronously lists the objects in a given bucket.
         /// </summary>
         /// <remarks>
         /// This method fetches the objects lazily, making requests to the underlying service
@@ -59,8 +53,9 @@ namespace Google.Storage.V1
         /// This parameter may be null, in which case no filtering is performed.</param>
         /// <param name="options">The options for the operation. May be null, in which case
         /// defaults will be supplied.</param>
-        /// <returns>A sequence of objects within the bucket.</returns>
-        public virtual IEnumerable<Object> ListObjects(string bucket, string prefix, ListObjectsOptions options = null)
+        /// <returns>An sequence of pages of objects in the specified bucket.</returns>
+        public virtual IPagedEnumerable<Objects, Object> ListObjectsPageStream(
+            string bucket, string prefix, ListObjectsOptions options = null)
         {
             throw new NotImplementedException();
         }

--- a/test/Google.Storage.V1.IntegrationTests/CopyObjectTest.cs
+++ b/test/Google.Storage.V1.IntegrationTests/CopyObjectTest.cs
@@ -47,7 +47,8 @@ namespace Google.Storage.V1.IntegrationTests
             var destBucket = _fixture.SingleVersionBucket;
             var firstGenName = GenerateName();
             var secondGenName = GenerateName();
-            var generations = client.ListObjects(sourceBucket, sourceName, new ListObjectsOptions { Versions = true })
+            var generations = client.ListObjectsPageStream(sourceBucket, sourceName, new ListObjectsOptions { Versions = true })
+                .Flatten()
                 .Select(o => (long)o.Generation)
                 .OrderBy(o => o)
                 .ToList();

--- a/test/Google.Storage.V1.IntegrationTests/DeleteObjectTest.cs
+++ b/test/Google.Storage.V1.IntegrationTests/DeleteObjectTest.cs
@@ -140,7 +140,8 @@ namespace Google.Storage.V1.IntegrationTests
 
         private List<Object> ListObjects(string bucket, string name, bool versions) =>
             // Use the same prefix as the name - filtering to be certain later.
-            _fixture.Client.ListObjects(bucket, name, new ListObjectsOptions { Versions = versions })
+            _fixture.Client.ListObjectsPageStream(bucket, name, new ListObjectsOptions { Versions = versions })
+                .Flatten()
                 .Where(o => o.Name == name)
                 .ToList();
 

--- a/test/Google.Storage.V1.IntegrationTests/DownloadObjectTest.cs
+++ b/test/Google.Storage.V1.IntegrationTests/DownloadObjectTest.cs
@@ -115,7 +115,7 @@ namespace Google.Storage.V1.IntegrationTests
         {
             var bucket = _fixture.ReadBucket;
             var name = _fixture.SmallThenLargeObject;
-            var objects = _fixture.Client.ListObjects(bucket, name, new ListObjectsOptions { Versions = true }).ToList();
+            var objects = _fixture.Client.ListObjectsPageStream(bucket, name, new ListObjectsOptions { Versions = true }).Flatten().ToList();
             Assert.Equal(2, objects.Count);
 
             // Fetch them by generation and check size matches
@@ -132,7 +132,8 @@ namespace Google.Storage.V1.IntegrationTests
         {
             var bucket = _fixture.ReadBucket;
             var name = _fixture.SmallThenLargeObject;
-            var objects = _fixture.Client.ListObjects(bucket, name, new ListObjectsOptions { Versions = true }).OrderBy(x => x.Generation).ToList();
+            var objects = _fixture.Client.ListObjectsPageStream(bucket, name, new ListObjectsOptions { Versions = true })
+                .Flatten().OrderBy(x => x.Generation).ToList();
             Assert.Equal(2, objects.Count);
             Assert.NotEqual(objects[0].Size, objects[1].Size);
 

--- a/test/Google.Storage.V1.IntegrationTests/GetObjectTest.cs
+++ b/test/Google.Storage.V1.IntegrationTests/GetObjectTest.cs
@@ -56,7 +56,8 @@ namespace Google.Storage.V1.IntegrationTests
             var name = _fixture.SmallThenLargeObject;
             // Fetch them via the list operation to start with
             var objects = _fixture.Client
-                .ListObjects(bucket, name, new ListObjectsOptions { Versions = true })
+                .ListObjectsPageStream(bucket, name, new ListObjectsOptions { Versions = true })
+                .Flatten()
                 .OrderBy(x => x.Generation)
                 .ToList();
 

--- a/test/Google.Storage.V1.IntegrationTests/ListBucketsTest.cs
+++ b/test/Google.Storage.V1.IntegrationTests/ListBucketsTest.cs
@@ -54,7 +54,7 @@ namespace Google.Storage.V1.IntegrationTests
         public async Task CancellationTokenRespected()
         {
             var cts = new CancellationTokenSource();
-            var task = _fixture.Client.ListAllBucketsAsync(_fixture.ProjectId, cancellationToken: cts.Token);
+            var task = _fixture.Client.ListBucketsPageStreamAsync(_fixture.ProjectId).ToList(cancellationToken: cts.Token);
             cts.Cancel();
             await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
         }
@@ -62,9 +62,9 @@ namespace Google.Storage.V1.IntegrationTests
         // Fetches buckets using the given options in each possible way, validating that the expected bucket names are returned.
         private async Task AssertBuckets(ListBucketsOptions options, params string[] expectedBucketNames)
         {
-            IEnumerable<Bucket> actual = _fixture.Client.ListBuckets(_fixture.ProjectId, options);
+            IEnumerable<Bucket> actual = _fixture.Client.ListBucketsPageStream(_fixture.ProjectId, options).Flatten();
             AssertBucketNames(actual, expectedBucketNames);
-            actual = await _fixture.Client.ListAllBucketsAsync(_fixture.ProjectId, options, CancellationToken.None);
+            actual = await _fixture.Client.ListBucketsPageStreamAsync(_fixture.ProjectId, options).Flatten().ToList();
             AssertBucketNames(actual, expectedBucketNames);
         }
 

--- a/test/Google.Storage.V1.IntegrationTests/ListObjectsTest.cs
+++ b/test/Google.Storage.V1.IntegrationTests/ListObjectsTest.cs
@@ -59,7 +59,7 @@ namespace Google.Storage.V1.IntegrationTests
         public async Task CancellationTokenRespected()
         {
             var cts = new CancellationTokenSource();
-            var task = _fixture.Client.ListAllObjectsAsync(_fixture.ReadBucket, null, cancellationToken: cts.Token);
+            var task = _fixture.Client.ListObjectsPageStreamAsync(_fixture.ReadBucket, null).ToList(cts.Token);
             cts.Cancel();
             await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);            
         }
@@ -79,9 +79,9 @@ namespace Google.Storage.V1.IntegrationTests
 
         private async Task AssertObjects(string prefix, ListObjectsOptions options, params string[] expectedNames)
         {
-            var actual = _fixture.Client.ListObjects(_fixture.ReadBucket, prefix, options);
+            var actual = _fixture.Client.ListObjectsPageStream(_fixture.ReadBucket, prefix, options).Flatten();
             AssertObjectNames(actual, expectedNames);
-            actual = await _fixture.Client.ListAllObjectsAsync(_fixture.ReadBucket, prefix, options, CancellationToken.None);
+            actual = await _fixture.Client.ListObjectsPageStreamAsync(_fixture.ReadBucket, prefix, options).Flatten().ToList();
             AssertObjectNames(actual, expectedNames);
         }
 

--- a/test/Google.Storage.V1.IntegrationTests/StorageFixture.cs
+++ b/test/Google.Storage.V1.IntegrationTests/StorageFixture.cs
@@ -148,7 +148,7 @@ namespace Google.Storage.V1.IntegrationTests
             var client = StorageClient.Create();
             foreach (var bucket in _bucketsToDelete)
             {
-                foreach (var obj in client.ListObjects(bucket, null, new ListObjectsOptions { Versions = true }).ToList())
+                foreach (var obj in client.ListObjectsPageStream(bucket, null, new ListObjectsOptions { Versions = true }).Flatten().ToList())
                 {
                     client.DeleteObject(obj, new DeleteObjectOptions { Generation = obj.Generation });
                 }


### PR DESCRIPTION
This implements the interfaces in a new package, and applies the pattern to Storage. I haven't tackled Bigquery yet, which is a bigger surface area.

Notes:

- The new package should probably end up in the google-api-dotnet-client repo; it was developed here for simplicity.
  (We could merge here then move, potentially.)
- There are no tests for the page streaming; they should be basically the same as in GAX, adapted for the REST requests.
- We're only ever showing Flatten(), which makes this look more long-winded than before in all our snippets. Need to look at
  this carefully before pushing forward.
- Docs required!

Eventually, this will address #115.

@csells to comment on usability of snippet changes. (Bear in mind the non-trivial use cases this enables.)