### PR TITLE
DatastoreDb API improvements

### DIFF
--- a/snippets/Google.Bigquery.V2.Snippets/Google.Bigquery.V2.Snippets.xproj
+++ b/snippets/Google.Bigquery.V2.Snippets/Google.Bigquery.V2.Snippets.xproj
@@ -9,9 +9,8 @@
     <ProjectGuid>a55f5009-37c2-4eb6-a100-ab86885a3ae9</ProjectGuid>
     <RootNamespace>Google.Bigquery.V2.Snippets</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/snippets/Google.Datastore.V1Beta3.Snippets/Google.Datastore.V1Beta3.Snippets.xproj
+++ b/snippets/Google.Datastore.V1Beta3.Snippets/Google.Datastore.V1Beta3.Snippets.xproj
@@ -4,15 +4,13 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>19377c99-47b6-4a5c-bc1c-01518d8bbd2f</ProjectGuid>
     <RootNamespace>Google.Datastore.V1Beta3.Snippets</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/snippets/Google.Pubsub.V1.Snippets/Google.Pubsub.V1.Snippets.xproj
+++ b/snippets/Google.Pubsub.V1.Snippets/Google.Pubsub.V1.Snippets.xproj
@@ -9,9 +9,8 @@
     <ProjectGuid>60e5f4c2-7a10-41f1-a247-14c346a8e33a</ProjectGuid>
     <RootNamespace>Google.Pubsub.V1.Snippets</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/snippets/Google.Storage.V1.Snippets/Google.Storage.V1.Snippets.xproj
+++ b/snippets/Google.Storage.V1.Snippets/Google.Storage.V1.Snippets.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>4a4d750b-97e7-49d6-afbe-d07cbcf89a1f</ProjectGuid>
     <RootNamespace>Google.Storage.V1.Snippets</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Google.Bigquery.V2/Google.Bigquery.V2.xproj
+++ b/src/Google.Bigquery.V2/Google.Bigquery.V2.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>1a49495f-b749-42f6-ae05-28b1b3e1edf3</ProjectGuid>
     <RootNamespace>Google.Bigquery.V2</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Google.Datastore.V1Beta3/DatastoreDb.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreDb.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using static Google.Datastore.V1Beta3.QueryResultBatch.Types;
 using static Google.Datastore.V1Beta3.ReadOptions.Types;
 
@@ -152,6 +153,22 @@ namespace Google.Datastore.V1Beta3
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Perform a single asynchronous <see cref="DatastoreClient.RunQueryAsync(string, PartitionId, ReadOptions, Query, CallSettings)"/> operation
+        /// using this object's partition ID and the specified read consistency, not in a transaction.
+        /// </summary>
+        /// <remarks>
+        /// To automatically stream pages of results, use <see cref="RunQueryPageStreamAsync(Query, ReadConsistency?, CallSettings)"/>.
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="readConsistency">The desired read consistency of the query, or null to use the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The response for the given query operation.</returns>
+        public virtual Task<RunQueryResponse> RunQueryAsync(Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
         // Note: no pagestreaming yet for GQL as it's tough to modify the limit/offset automatically.
 
         /// <summary>
@@ -163,6 +180,19 @@ namespace Google.Datastore.V1Beta3
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The response for the given query operation.</returns>
         public virtual RunQueryResponse RunQuery(GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Perform a single asynchronous <see cref="DatastoreClient.RunQueryAsync(string, PartitionId, ReadOptions, Query, CallSettings)"/> operation
+        /// using this object's partition ID and the specified read consistency, not in a transaction.
+        /// </summary>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="readConsistency">The desired read consistency of the query, or null to use the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The response for the given query operation.</returns>
+        public virtual Task<RunQueryResponse> RunQueryAsync(GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -187,11 +217,41 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <summary>
+        /// Executes the given query, automatically streaming the pages of results asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// To start where a previous operation left off, specify <see cref="Query.StartCursor"/>.
+        /// If you have been using <see cref="FixedSizePage{Entity}"/>, convert the <see cref="FixedSizePage{TResource}.NextPageToken"/>
+        /// string into a <see cref="ByteString"/> using <see cref="ByteString.FromBase64(string)"/>.
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="readConsistency">The desired read consistency of the query, or null to use
+        /// the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A sequence of pages of entities.</returns>
+        public virtual IPagedAsyncEnumerable<RunQueryResponse, Entity> RunQueryPageStreamAsync(
+            Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        /// <summary>
         /// Begins a transaction, returning a <see cref="DatastoreTransaction"/> which can be used to operate on the transaction.
         /// </summary>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A new <see cref="DatastoreTransaction"/> for this object's project.</returns>
         public virtual DatastoreTransaction BeginTransaction(CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Begins a transaction asynchronously, returning a <see cref="DatastoreTransaction"/> which can be used to operate on the transaction.
+        /// </summary>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A new <see cref="DatastoreTransaction"/> for this object's project.</returns>
+        public virtual Task<DatastoreTransaction> BeginTransactionAsync(CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -226,6 +286,44 @@ namespace Google.Datastore.V1Beta3
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A collection of complete keys with allocated IDs, in the same order as <paramref name="keys"/>.</returns>
         public virtual IReadOnlyList<Key> AllocateIds(IEnumerable<Key> keys, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Allocates an ID for a single incomplete key asynchronously.
+        /// </summary>
+        /// <remarks>This method simply delegates to <see cref="AllocateIdsAsync(IEnumerable{Key},CallSettings)"/>.</remarks>
+        /// <param name="key">The incomplete key to allocate an ID for.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The complete key.</returns>
+        public async Task<Key> AllocateIdAsync(Key key, CallSettings callSettings = null)
+        {
+            var results = await AllocateIdsAsync(new[] { key }, callSettings).ConfigureAwait(false);
+            return results[0];
+        }
+
+        /// <summary>
+        /// Allocates IDs for a collection of incomplete keys asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="AllocateIdsAsync(IEnumerable{Key},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="AllocateIdsAsync(IEnumerable{Key},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="keys">The incomplete keys. Must not be null or contain null elements.</param>
+        /// <returns>A collection of complete keys with allocated IDs, in the same order as <paramref name="keys"/>.</returns>
+        public Task<IReadOnlyList<Key>> AllocateIdsAsync(params Key[] keys) => AllocateIdsAsync(keys, null);
+
+        /// <summary>
+        /// Allocates IDs for a collection of incomplete keys asynchronously.
+        /// </summary>
+        /// <param name="keys">The incomplete keys. Must not be null or contain null elements.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A collection of complete keys with allocated IDs, in the same order as <paramref name="keys"/>.</returns>
+        public virtual Task<IReadOnlyList<Key>> AllocateIdsAsync(IEnumerable<Key> keys, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -275,6 +373,55 @@ namespace Google.Datastore.V1Beta3
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Looks up a single entity by key asynchronously.
+        /// </summary>
+        /// <remarks>This method simply delegates to <see cref="LookupAsync(IEnumerable{Key}, ReadConsistency?, CallSettings)"/>.</remarks>
+        /// <param name="key">The key to look up. Must not be null, and must be complete.</param>
+        /// <param name="readConsistency">The desired read consistency of the lookup, or null to use the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The entity with the specified key, or <c>null</c> if no such entity exists.</returns>
+        public async Task<Entity> LookupAsync(Key key, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        {
+            var results = await LookupAsync(new[] { key }, readConsistency, callSettings).ConfigureAwait(false);
+            return results[0];
+        }
+
+        /// <summary>
+        /// Looks up a collection of entities by key asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This call may perform multiple RPC operations in order to look up all keys.
+        /// </para>
+        /// <para>
+        /// This overload does not support the <see cref="ReadConsistency"/> or <see cref="CallSettings "/>to be specified due to restrictions with
+        /// methods containing a parameter array and optional parameters.
+        /// It simply delegates to <see cref="LookupAsync(IEnumerable{Key}, ReadConsistency?, CallSettings)"/>, passing in a <c>null</c>
+        /// value for the read consistency and all settings.
+        /// </para>
+        /// </remarks>
+        /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
+        /// <returns>A collection of entities with the same size as <paramref name="keys"/>, containing corresponding entity
+        /// references, or <c>null</c> where the key was not found.</returns>
+        public Task<IReadOnlyList<Entity>> LookupAsync(params Key[] keys) => LookupAsync(keys, null, null);
+
+        /// <summary>
+        /// Looks up a collection of entities by key asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// This call may perform multiple RPC operations in order to look up all keys.
+        /// </remarks>
+        /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
+        /// <param name="readConsistency">The desired read consistency of the lookup, or null to use the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A collection of entities with the same size as <paramref name="keys"/>, containing corresponding entity
+        /// references, or <c>null</c> where the key was not found.</returns>
+        public virtual Task<IReadOnlyList<Entity>> LookupAsync(IEnumerable<Key> keys, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
         // Static to allow reuse within DatastoreTransaction.
         internal static IReadOnlyList<Entity> LookupImpl(
             DatastoreClient client,
@@ -293,6 +440,36 @@ namespace Google.Datastore.V1Beta3
             while (keysToFetch.Count() > 0)
             {
                 var response = client.Lookup(projectId, readOptions, keysToFetch, callSettings);
+                foreach (var found in response.Found)
+                {
+                    foreach (var index in keyToIndex[found.Entity.Key])
+                    {
+                        result[index] = found.Entity;
+                    }
+                }
+                keysToFetch = response.Deferred;
+            }
+            return result;
+        }
+
+        // Static to allow reuse within DatastoreTransaction.
+        internal static async Task<IReadOnlyList<Entity>> LookupImplAsync(
+            DatastoreClient client,
+            string projectId,
+            ReadOptions readOptions,
+            IEnumerable<Key> keys,
+            CallSettings callSettings)
+        {
+            // Just so we can iterate multiple times safely.
+            keys = keys.ToList();
+            GaxPreconditions.CheckArgument(keys.All(x => x != null), nameof(keys), "Key collection must not contain null elements");
+            var keyToIndex = keys.Select((value, index) => new { value, index }).ToLookup(pair => pair.value, pair => pair.index);
+            IEnumerable<Key> keysToFetch = new HashSet<Key>(keys);
+            Entity[] result = new Entity[keys.Count()];
+            // TODO: Limit how many times we go round? Ensure that we make progress on each iteration?
+            while (keysToFetch.Count() > 0)
+            {
+                var response = await client.LookupAsync(projectId, readOptions, keysToFetch, callSettings).ConfigureAwait(false);
                 foreach (var found in response.Found)
                 {
                     foreach (var index in keyToIndex[found.Entity.Key])
@@ -341,6 +518,43 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <summary>
+        /// Inserts a single entity, non-transactionally and asynchronously.
+        /// </summary>
+        /// <remarks>This method simply delegates to <see cref="InsertAsync(IEnumerable{Entity}, CallSettings)"/>.</remarks>
+        /// <param name="entity">The entity to insert. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The key of the inserted entity.</returns>
+        public async Task<Key> InsertAsync(Entity entity, CallSettings callSettings = null)
+        {
+            var results = await InsertAsync(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings).ConfigureAwait(false);
+            return results[0];
+        }
+
+        /// <summary>
+        /// Inserts a collection of entities, non-transactionally and asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="InsertAsync(IEnumerable{Entity},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="InsertAsync(IEnumerable{Entity},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="entities">The entities to insert. Must not be null or contain null entries.</param>
+        /// <returns>A collection of keys of inserted entities, in the same order as <paramref name="entities"/>.</returns>
+        public Task<IReadOnlyList<Key>> InsertAsync(params Entity[] entities) => InsertAsync(entities, null);
+        /// <summary>
+        /// Inserts a collection of entities, non-transactionally and asynchronously.
+        /// </summary>
+        /// <param name="entities">The entities to insert. Must not be null or contain null entries.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A collection of keys of inserted entities, in the same order as <paramref name="entities"/>.</returns>
+        public virtual Task<IReadOnlyList<Key>> InsertAsync(IEnumerable<Entity> entities, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Upserts a single entity, non-transactionally.
         /// </summary>
         /// <remarks>This method simply delegates to <see cref="Upsert(IEnumerable{Entity}, CallSettings)"/>.</remarks>
@@ -369,6 +583,43 @@ namespace Google.Datastore.V1Beta3
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A collection of keys of upserted entities, in the same order as <paramref name="entities"/>.</returns>
         public virtual IReadOnlyList<Key> Upsert(IEnumerable<Entity> entities, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Upserts a single entity, non-transactionally and asynchronously.
+        /// </summary>
+        /// <remarks>This method simply delegates to <see cref="UpsertAsync(IEnumerable{Entity}, CallSettings)"/>.</remarks>
+        /// <param name="entity">The entity to upsert. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The key of the upserted entity.</returns>
+        public async Task<Key> UpsertAsync(Entity entity, CallSettings callSettings = null)
+        {
+            var results = await UpsertAsync(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings).ConfigureAwait(false);
+            return results[0];
+        }
+
+        /// <summary>
+        /// Upserts a collection of entities, non-transactionally and asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="UpsertAsync(IEnumerable{Entity},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="UpsertAsync(IEnumerable{Entity},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="entities">The entities to upsert. Must not be null or contain null entries.</param>
+        /// <returns>A collection of keys of upserted entities, in the same order as <paramref name="entities"/>.</returns>
+        public Task<IReadOnlyList<Key>> UpsertAsync(params Entity[] entities) => UpsertAsync(entities, null);
+        /// <summary>
+        /// Upserts a collection of entities, non-transactionally and asynchronously.
+        /// </summary>
+        /// <param name="entities">The entities to upsert. Must not be null or contain null entries.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A collection of keys of upserted entities, in the same order as <paramref name="entities"/>.</returns>
+        public virtual Task<IReadOnlyList<Key>> UpsertAsync(IEnumerable<Entity> entities, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -407,6 +658,42 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <summary>
+        /// Updates a single entity, non-transactionally and asynchronously.
+        /// </summary>
+        /// <remarks>This method simply delegates to <see cref="UpdateAsync(IEnumerable{Entity},CallSettings)"/>.</remarks>
+        /// <param name="entity">The entity to update. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The key of the updated entity.</returns>
+        public async Task<Key> UpdateAsync(Entity entity, CallSettings callSettings = null)
+        {
+            var results = await UpdateAsync(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings).ConfigureAwait(false);
+            return results[0];
+        }
+        /// <summary>
+        /// Updates a collection of entities, non-transactionally and asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="UpdateAsync(IEnumerable{Entity},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="UpdateAsync(IEnumerable{Entity},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="entities">The entities to update. Must not be null or contain null entries.</param>
+        /// <returns>A collection of keys of updated entities, in the same order as <paramref name="entities"/>.</returns>
+        public Task<IReadOnlyList<Key>> UpdateAsync(params Entity[] entities) => UpdateAsync(entities, null);
+        /// <summary>
+        /// Updates a collection of entities, non-transactionally and asynchronously.
+        /// </summary>
+        /// <param name="entities">The entities to update. Must not be null or contain null entries.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A collection of keys of updated entities, in the same order as <paramref name="entities"/>.</returns>
+        public virtual Task<IReadOnlyList<Key>> UpdateAsync(IEnumerable<Entity> entities, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Deletes a single entity, non-transactionally.
         /// </summary>
         /// <remarks>This method simply delegates to <see cref="Delete(IEnumerable{Entity},CallSettings)"/>.</remarks>
@@ -437,6 +724,36 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <summary>
+        /// Deletes a single entity, non-transactionally and asynchronously.
+        /// </summary>
+        /// <remarks>This method simply delegates to <see cref="DeleteAsync(IEnumerable{Entity},CallSettings)"/>.</remarks>
+        /// <param name="entity">The entity to delete. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        public Task DeleteAsync(Entity entity, CallSettings callSettings = null) =>
+            DeleteAsync(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings);
+        /// <summary>
+        /// Deletes a collection of entities, non-transactionally and asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="DeleteAsync(IEnumerable{Entity},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="DeleteAsync(IEnumerable{Entity},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="entities">The entities to delete. Must not be null or contain null entries.</param>
+        public Task DeleteAsync(params Entity[] entities) => DeleteAsync(entities, null);
+        /// <summary>
+        /// Deletes a collection of entities, non-transactionally and asynchronously.
+        /// </summary>
+        /// <param name="entities">The entities to delete. Must not be null or contain null entries.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        public virtual Task DeleteAsync(IEnumerable<Entity> entities, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Deletes a single key, non-transactionally.
         /// </summary>
         /// <remarks>This method simply delegates to <see cref="Delete(IEnumerable{Key},CallSettings)"/>.</remarks>
@@ -462,6 +779,36 @@ namespace Google.Datastore.V1Beta3
         /// <param name="keys">The keys to delete. Must not be null or contain null entries.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         public virtual void Delete(IEnumerable<Key> keys, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Deletes a single key, non-transactionally and asynchronously.
+        /// </summary>
+        /// <remarks>This method simply delegates to <see cref="DeleteAsync(IEnumerable{Key},CallSettings)"/>.</remarks>
+        /// <param name="key">The key to delete. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        public Task DeleteAsync(Key key, CallSettings callSettings = null) =>
+            DeleteAsync(new[] { GaxPreconditions.CheckNotNull(key, nameof(key)) }, callSettings);
+        /// <summary>
+        /// Deletes a collection of keys, non-transactionally and asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="DeleteAsync(IEnumerable{Key},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="DeleteAsync(IEnumerable{Key},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
+        /// <param name="keys">The keys to delete. Must not be null or contain null entries.</param>
+        public Task DeleteAsync(params Key[] keys) => DeleteAsync(keys, null);
+        /// <summary>
+        /// Deletes a collection of keys, non-transactionally and asynchronously.
+        /// </summary>
+        /// <param name="keys">The keys to delete. Must not be null or contain null entries.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        public virtual Task DeleteAsync(IEnumerable<Key> keys, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }

--- a/src/Google.Datastore.V1Beta3/DatastoreDb.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreDb.cs
@@ -263,7 +263,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="key">The incomplete key to allocate an ID for.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The complete key.</returns>
-        public Key AllocateId(Key key, CallSettings callSettings = null) => AllocateIds(new[] { key }, callSettings)[0];
+        public virtual Key AllocateId(Key key, CallSettings callSettings = null) => AllocateIds(new[] { key }, callSettings)[0];
 
         /// <summary>
         /// Allocates IDs for a collection of incomplete keys.
@@ -277,7 +277,7 @@ namespace Google.Datastore.V1Beta3
         /// </remarks>
         /// <param name="keys">The incomplete keys. Must not be null or contain null elements.</param>
         /// <returns>A collection of complete keys with allocated IDs, in the same order as <paramref name="keys"/>.</returns>
-        public IReadOnlyList<Key> AllocateIds(params Key[] keys) => AllocateIds(keys, null);
+        public virtual IReadOnlyList<Key> AllocateIds(params Key[] keys) => AllocateIds(keys, null);
 
         /// <summary>
         /// Allocates IDs for a collection of incomplete keys.
@@ -297,7 +297,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="key">The incomplete key to allocate an ID for.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The complete key.</returns>
-        public async Task<Key> AllocateIdAsync(Key key, CallSettings callSettings = null)
+        public virtual async Task<Key> AllocateIdAsync(Key key, CallSettings callSettings = null)
         {
             var results = await AllocateIdsAsync(new[] { key }, callSettings).ConfigureAwait(false);
             return results[0];
@@ -315,7 +315,7 @@ namespace Google.Datastore.V1Beta3
         /// </remarks>
         /// <param name="keys">The incomplete keys. Must not be null or contain null elements.</param>
         /// <returns>A collection of complete keys with allocated IDs, in the same order as <paramref name="keys"/>.</returns>
-        public Task<IReadOnlyList<Key>> AllocateIdsAsync(params Key[] keys) => AllocateIdsAsync(keys, null);
+        public virtual Task<IReadOnlyList<Key>> AllocateIdsAsync(params Key[] keys) => AllocateIdsAsync(keys, null);
 
         /// <summary>
         /// Allocates IDs for a collection of incomplete keys asynchronously.
@@ -336,7 +336,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="readConsistency">The desired read consistency of the lookup, or null to use the default.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The entity with the specified key, or <c>null</c> if no such entity exists.</returns>
-        public Entity Lookup(Key key, ReadConsistency? readConsistency = null, CallSettings callSettings = null) => Lookup(new[] { key }, readConsistency, callSettings)[0];
+        public virtual Entity Lookup(Key key, ReadConsistency? readConsistency = null, CallSettings callSettings = null) => Lookup(new[] { key }, readConsistency, callSettings)[0];
 
         /// <summary>
         /// Looks up a collection of entities by key.
@@ -355,7 +355,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
         /// <returns>A collection of entities with the same size as <paramref name="keys"/>, containing corresponding entity
         /// references, or <c>null</c> where the key was not found.</returns>
-        public IReadOnlyList<Entity> Lookup(params Key[] keys) => Lookup(keys, null, null);
+        public virtual IReadOnlyList<Entity> Lookup(params Key[] keys) => Lookup(keys, null, null);
 
         /// <summary>
         /// Looks up a collection of entities by key.
@@ -381,7 +381,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="readConsistency">The desired read consistency of the lookup, or null to use the default.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The entity with the specified key, or <c>null</c> if no such entity exists.</returns>
-        public async Task<Entity> LookupAsync(Key key, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        public virtual async Task<Entity> LookupAsync(Key key, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             var results = await LookupAsync(new[] { key }, readConsistency, callSettings).ConfigureAwait(false);
             return results[0];
@@ -404,7 +404,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
         /// <returns>A collection of entities with the same size as <paramref name="keys"/>, containing corresponding entity
         /// references, or <c>null</c> where the key was not found.</returns>
-        public Task<IReadOnlyList<Entity>> LookupAsync(params Key[] keys) => LookupAsync(keys, null, null);
+        public virtual Task<IReadOnlyList<Entity>> LookupAsync(params Key[] keys) => LookupAsync(keys, null, null);
 
         /// <summary>
         /// Looks up a collection of entities by key asynchronously.
@@ -491,7 +491,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="entity">The entity to insert. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The key of the inserted entity.</returns>
-        public Key Insert(Entity entity, CallSettings callSettings = null) =>
+        public virtual Key Insert(Entity entity, CallSettings callSettings = null) =>
             Insert(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings)[0];
         /// <summary>
         /// Inserts a collection of entities, non-transactionally.
@@ -505,7 +505,7 @@ namespace Google.Datastore.V1Beta3
         /// </remarks>
         /// <param name="entities">The entities to insert. Must not be null or contain null entries.</param>
         /// <returns>A collection of keys of inserted entities, in the same order as <paramref name="entities"/>.</returns>
-        public IReadOnlyList<Key> Insert(params Entity[] entities) => Insert(entities, null);
+        public virtual IReadOnlyList<Key> Insert(params Entity[] entities) => Insert(entities, null);
         /// <summary>
         /// Inserts a collection of entities, non-transactionally.
         /// </summary>
@@ -524,7 +524,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="entity">The entity to insert. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The key of the inserted entity.</returns>
-        public async Task<Key> InsertAsync(Entity entity, CallSettings callSettings = null)
+        public virtual async Task<Key> InsertAsync(Entity entity, CallSettings callSettings = null)
         {
             var results = await InsertAsync(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings).ConfigureAwait(false);
             return results[0];
@@ -542,7 +542,7 @@ namespace Google.Datastore.V1Beta3
         /// </remarks>
         /// <param name="entities">The entities to insert. Must not be null or contain null entries.</param>
         /// <returns>A collection of keys of inserted entities, in the same order as <paramref name="entities"/>.</returns>
-        public Task<IReadOnlyList<Key>> InsertAsync(params Entity[] entities) => InsertAsync(entities, null);
+        public virtual Task<IReadOnlyList<Key>> InsertAsync(params Entity[] entities) => InsertAsync(entities, null);
         /// <summary>
         /// Inserts a collection of entities, non-transactionally and asynchronously.
         /// </summary>
@@ -561,7 +561,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="entity">The entity to upsert. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The key of the upserted entity.</returns>
-        public Key Upsert(Entity entity, CallSettings callSettings = null) =>
+        public virtual Key Upsert(Entity entity, CallSettings callSettings = null) =>
             Upsert(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings)[0];
         /// <summary>
         /// Upserts a collection of entities, non-transactionally.
@@ -575,7 +575,7 @@ namespace Google.Datastore.V1Beta3
         /// </remarks>
         /// <param name="entities">The entities to upsert. Must not be null or contain null entries.</param>
         /// <returns>A collection of keys of upserted entities, in the same order as <paramref name="entities"/>.</returns>
-        public IReadOnlyList<Key> Upsert(params Entity[] entities) => Upsert(entities, null);
+        public virtual IReadOnlyList<Key> Upsert(params Entity[] entities) => Upsert(entities, null);
         /// <summary>
         /// Upserts a collection of entities, non-transactionally.
         /// </summary>
@@ -594,7 +594,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="entity">The entity to upsert. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The key of the upserted entity.</returns>
-        public async Task<Key> UpsertAsync(Entity entity, CallSettings callSettings = null)
+        public virtual async Task<Key> UpsertAsync(Entity entity, CallSettings callSettings = null)
         {
             var results = await UpsertAsync(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings).ConfigureAwait(false);
             return results[0];
@@ -612,7 +612,7 @@ namespace Google.Datastore.V1Beta3
         /// </remarks>
         /// <param name="entities">The entities to upsert. Must not be null or contain null entries.</param>
         /// <returns>A collection of keys of upserted entities, in the same order as <paramref name="entities"/>.</returns>
-        public Task<IReadOnlyList<Key>> UpsertAsync(params Entity[] entities) => UpsertAsync(entities, null);
+        public virtual Task<IReadOnlyList<Key>> UpsertAsync(params Entity[] entities) => UpsertAsync(entities, null);
         /// <summary>
         /// Upserts a collection of entities, non-transactionally and asynchronously.
         /// </summary>
@@ -631,7 +631,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="entity">The entity to update. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The key of the updated entity.</returns>
-        public Key Update(Entity entity, CallSettings callSettings = null) =>
+        public virtual Key Update(Entity entity, CallSettings callSettings = null) =>
             Update(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings)[0];
         /// <summary>
         /// Updates a collection of entities, non-transactionally.
@@ -645,7 +645,7 @@ namespace Google.Datastore.V1Beta3
         /// </remarks>
         /// <param name="entities">The entities to update. Must not be null or contain null entries.</param>
         /// <returns>A collection of keys of updated entities, in the same order as <paramref name="entities"/>.</returns>
-        public IReadOnlyList<Key> Update(params Entity[] entities) => Update(entities, null);
+        public virtual IReadOnlyList<Key> Update(params Entity[] entities) => Update(entities, null);
         /// <summary>
         /// Updates a collection of entities, non-transactionally.
         /// </summary>
@@ -664,7 +664,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="entity">The entity to update. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The key of the updated entity.</returns>
-        public async Task<Key> UpdateAsync(Entity entity, CallSettings callSettings = null)
+        public virtual async Task<Key> UpdateAsync(Entity entity, CallSettings callSettings = null)
         {
             var results = await UpdateAsync(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings).ConfigureAwait(false);
             return results[0];
@@ -681,7 +681,7 @@ namespace Google.Datastore.V1Beta3
         /// </remarks>
         /// <param name="entities">The entities to update. Must not be null or contain null entries.</param>
         /// <returns>A collection of keys of updated entities, in the same order as <paramref name="entities"/>.</returns>
-        public Task<IReadOnlyList<Key>> UpdateAsync(params Entity[] entities) => UpdateAsync(entities, null);
+        public virtual Task<IReadOnlyList<Key>> UpdateAsync(params Entity[] entities) => UpdateAsync(entities, null);
         /// <summary>
         /// Updates a collection of entities, non-transactionally and asynchronously.
         /// </summary>
@@ -699,7 +699,7 @@ namespace Google.Datastore.V1Beta3
         /// <remarks>This method simply delegates to <see cref="Delete(IEnumerable{Entity},CallSettings)"/>.</remarks>
         /// <param name="entity">The entity to delete. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        public void Delete(Entity entity, CallSettings callSettings = null) =>
+        public virtual void Delete(Entity entity, CallSettings callSettings = null) =>
             Delete(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings);
         /// <summary>
         /// Deletes a collection of entities, non-transactionally.
@@ -712,7 +712,7 @@ namespace Google.Datastore.V1Beta3
         /// </para>
         /// </remarks>
         /// <param name="entities">The entities to delete. Must not be null or contain null entries.</param>
-        public void Delete(params Entity[] entities) => Delete(entities, null);
+        public virtual void Delete(params Entity[] entities) => Delete(entities, null);
         /// <summary>
         /// Deletes a collection of entities, non-transactionally.
         /// </summary>
@@ -729,7 +729,7 @@ namespace Google.Datastore.V1Beta3
         /// <remarks>This method simply delegates to <see cref="DeleteAsync(IEnumerable{Entity},CallSettings)"/>.</remarks>
         /// <param name="entity">The entity to delete. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        public Task DeleteAsync(Entity entity, CallSettings callSettings = null) =>
+        public virtual Task DeleteAsync(Entity entity, CallSettings callSettings = null) =>
             DeleteAsync(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings);
         /// <summary>
         /// Deletes a collection of entities, non-transactionally and asynchronously.
@@ -742,7 +742,7 @@ namespace Google.Datastore.V1Beta3
         /// </para>
         /// </remarks>
         /// <param name="entities">The entities to delete. Must not be null or contain null entries.</param>
-        public Task DeleteAsync(params Entity[] entities) => DeleteAsync(entities, null);
+        public virtual Task DeleteAsync(params Entity[] entities) => DeleteAsync(entities, null);
         /// <summary>
         /// Deletes a collection of entities, non-transactionally and asynchronously.
         /// </summary>
@@ -759,7 +759,7 @@ namespace Google.Datastore.V1Beta3
         /// <remarks>This method simply delegates to <see cref="Delete(IEnumerable{Key},CallSettings)"/>.</remarks>
         /// <param name="key">The key to delete. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
-        public void Delete(Key key, CallSettings callSettings = null) =>
+        public virtual void Delete(Key key, CallSettings callSettings = null) =>
             Delete(new[] { GaxPreconditions.CheckNotNull(key, nameof(key)) }, callSettings);
         /// <summary>
         /// Deletes a collection of keys, non-transactionally.
@@ -772,7 +772,7 @@ namespace Google.Datastore.V1Beta3
         /// </para>
         /// </remarks>
         /// <param name="keys">The keys to delete. Must not be null or contain null entries.</param>
-        public void Delete(params Key[] keys) => Delete(keys, null);
+        public virtual void Delete(params Key[] keys) => Delete(keys, null);
         /// <summary>
         /// Deletes a collection of keys, non-transactionally.
         /// </summary>
@@ -789,7 +789,7 @@ namespace Google.Datastore.V1Beta3
         /// <remarks>This method simply delegates to <see cref="DeleteAsync(IEnumerable{Key},CallSettings)"/>.</remarks>
         /// <param name="key">The key to delete. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
-        public Task DeleteAsync(Key key, CallSettings callSettings = null) =>
+        public virtual Task DeleteAsync(Key key, CallSettings callSettings = null) =>
             DeleteAsync(new[] { GaxPreconditions.CheckNotNull(key, nameof(key)) }, callSettings);
         /// <summary>
         /// Deletes a collection of keys, non-transactionally and asynchronously.
@@ -802,7 +802,7 @@ namespace Google.Datastore.V1Beta3
         /// </para>
         /// </remarks>
         /// <param name="keys">The keys to delete. Must not be null or contain null entries.</param>
-        public Task DeleteAsync(params Key[] keys) => DeleteAsync(keys, null);
+        public virtual Task DeleteAsync(params Key[] keys) => DeleteAsync(keys, null);
         /// <summary>
         /// Deletes a collection of keys, non-transactionally and asynchronously.
         /// </summary>

--- a/src/Google.Datastore.V1Beta3/DatastoreDb.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreDb.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using static Google.Datastore.V1Beta3.CommitRequest.Types;
 using static Google.Datastore.V1Beta3.QueryResultBatch.Types;
 using static Google.Datastore.V1Beta3.ReadOptions.Types;
 
@@ -127,10 +126,6 @@ namespace Google.Datastore.V1Beta3
         public static DatastoreDb Create(string projectId, string namespaceId = "", DatastoreClient client = null) =>
             new DatastoreDbImpl(projectId, namespaceId, client ?? DatastoreClient.Create());
 
-        public DatastoreDb()
-        {
-        }
-
         /// <summary>
         /// Creates a key factory for root entities in this objects's partition.
         /// </summary>
@@ -146,12 +141,13 @@ namespace Google.Datastore.V1Beta3
         /// using this object's partition ID and the specified read consistency, not in a transaction.
         /// </summary>
         /// <remarks>
-        /// To automatically stream pages of results, use <see cref="RunQueryPageStream(Query, ReadConsistency?)"/>.
+        /// To automatically stream pages of results, use <see cref="RunQueryPageStream(Query, ReadConsistency?, CallSettings)"/>.
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">The desired read consistency of the query, or null to use the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The response for the given query operation.</returns>
-        public virtual RunQueryResponse RunQuery(Query query, ReadConsistency? readConsistency = null)
+        public virtual RunQueryResponse RunQuery(Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -164,8 +160,9 @@ namespace Google.Datastore.V1Beta3
         /// </summary>
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">The desired read consistency of the query, or null to use the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The response for the given query operation.</returns>
-        public virtual RunQueryResponse RunQuery(GqlQuery query, ReadConsistency? readConsistency = null)
+        public virtual RunQueryResponse RunQuery(GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -181,8 +178,10 @@ namespace Google.Datastore.V1Beta3
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">The desired read consistency of the query, or null to use
         /// the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A sequence of pages of entities.</returns>
-        public virtual IPagedEnumerable<RunQueryResponse, Entity> RunQueryPageStream(Query query, ReadConsistency? readConsistency = null)
+        public virtual IPagedEnumerable<RunQueryResponse, Entity> RunQueryPageStream(
+            Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -190,8 +189,9 @@ namespace Google.Datastore.V1Beta3
         /// <summary>
         /// Begins a transaction, returning a <see cref="DatastoreTransaction"/> which can be used to operate on the transaction.
         /// </summary>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A new <see cref="DatastoreTransaction"/> for this object's project.</returns>
-        public virtual DatastoreTransaction BeginTransaction()
+        public virtual DatastoreTransaction BeginTransaction(CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -199,25 +199,33 @@ namespace Google.Datastore.V1Beta3
         /// <summary>
         /// Allocates an ID for a single incomplete key.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="AllocateIds(Key[])"/>.</remarks>
+        /// <remarks>This method simply delegates to <see cref="AllocateIds(IEnumerable{Key},CallSettings)"/>.</remarks>
         /// <param name="key">The incomplete key to allocate an ID for.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The complete key.</returns>
-        public Key AllocateId(Key key) => AllocateIds(new[] { key })[0];
+        public Key AllocateId(Key key, CallSettings callSettings = null) => AllocateIds(new[] { key }, callSettings)[0];
 
         /// <summary>
         /// Allocates IDs for a collection of incomplete keys.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="AllocateIds(IEnumerable{Key})"/>.</remarks>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="AllocateIds(IEnumerable{Key},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="AllocateIds(IEnumerable{Key},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
         /// <param name="keys">The incomplete keys. Must not be null or contain null elements.</param>
         /// <returns>A collection of complete keys with allocated IDs, in the same order as <paramref name="keys"/>.</returns>
-        public IReadOnlyList<Key> AllocateIds(params Key[] keys) => AllocateIds((IEnumerable<Key>)keys);
+        public IReadOnlyList<Key> AllocateIds(params Key[] keys) => AllocateIds(keys, null);
 
         /// <summary>
         /// Allocates IDs for a collection of incomplete keys.
         /// </summary>
         /// <param name="keys">The incomplete keys. Must not be null or contain null elements.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A collection of complete keys with allocated IDs, in the same order as <paramref name="keys"/>.</returns>
-        public virtual IReadOnlyList<Key> AllocateIds(IEnumerable<Key> keys)
+        public virtual IReadOnlyList<Key> AllocateIds(IEnumerable<Key> keys, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -225,40 +233,55 @@ namespace Google.Datastore.V1Beta3
         /// <summary>
         /// Looks up a single entity by key.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="Lookup(IEnumerable{Key}, ReadConsistency?)"/>.</remarks>
+        /// <remarks>This method simply delegates to <see cref="Lookup(IEnumerable{Key}, ReadConsistency?, CallSettings)"/>.</remarks>
         /// <param name="key">The key to look up. Must not be null, and must be complete.</param>
         /// <param name="readConsistency">The desired read consistency of the lookup, or null to use the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The entity with the specified key, or <c>null</c> if no such entity exists.</returns>
-        public Entity Lookup(Key key, ReadConsistency? readConsistency = null) => Lookup(new[] { key }, readConsistency)[0];
+        public Entity Lookup(Key key, ReadConsistency? readConsistency = null, CallSettings callSettings = null) => Lookup(new[] { key }, readConsistency, callSettings)[0];
 
         /// <summary>
         /// Looks up a collection of entities by key.
         /// </summary>
         /// <remarks>
-        /// This overload does not support the <see cref="ReadConsistency"/> to be specified due to restrictions with
+        /// <para>
+        /// This call may perform multiple RPC operations in order to look up all keys.
+        /// </para>
+        /// <para>
+        /// This overload does not support the <see cref="ReadConsistency"/> or <see cref="CallSettings "/>to be specified due to restrictions with
         /// methods containing a parameter array and optional parameters.
-        /// It simply delegates to <see cref="Lookup(IEnumerable{Key}, ReadConsistency?)"/>, passing in a <c>null</c>
-        /// value for the read consistency.
+        /// It simply delegates to <see cref="Lookup(IEnumerable{Key}, ReadConsistency?, CallSettings)"/>, passing in a <c>null</c>
+        /// value for the read consistency and all settings.
+        /// </para>
         /// </remarks>
         /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
         /// <returns>A collection of entities with the same size as <paramref name="keys"/>, containing corresponding entity
         /// references, or <c>null</c> where the key was not found.</returns>
-        public IReadOnlyList<Entity> Lookup(params Key[] keys) => Lookup(keys, null);
+        public IReadOnlyList<Entity> Lookup(params Key[] keys) => Lookup(keys, null, null);
 
         /// <summary>
         /// Looks up a collection of entities by key.
         /// </summary>
+        /// <remarks>
+        /// This call may perform multiple RPC operations in order to look up all keys.
+        /// </remarks>
         /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
         /// <param name="readConsistency">The desired read consistency of the lookup, or null to use the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A collection of entities with the same size as <paramref name="keys"/>, containing corresponding entity
         /// references, or <c>null</c> where the key was not found.</returns>
-        public virtual IReadOnlyList<Entity> Lookup(IEnumerable<Key> keys, ReadConsistency? readConsistency = null)
+        public virtual IReadOnlyList<Entity> Lookup(IEnumerable<Key> keys, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
 
         // Static to allow reuse within DatastoreTransaction.
-        internal static IReadOnlyList<Entity> LookupImpl(DatastoreClient client, string projectId, ReadOptions readOptions, IEnumerable<Key> keys)
+        internal static IReadOnlyList<Entity> LookupImpl(
+            DatastoreClient client,
+            string projectId,
+            ReadOptions readOptions,
+            IEnumerable<Key> keys,
+            CallSettings callSettings)
         {
             // Just so we can iterate multiple times safely.
             keys = keys.ToList();
@@ -269,7 +292,7 @@ namespace Google.Datastore.V1Beta3
             // TODO: Limit how many times we go round? Ensure that we make progress on each iteration?
             while (keysToFetch.Count() > 0)
             {
-                var response = client.Lookup(projectId, readOptions, keysToFetch);
+                var response = client.Lookup(projectId, readOptions, keysToFetch, callSettings);
                 foreach (var found in response.Found)
                 {
                     foreach (var index in keyToIndex[found.Entity.Key])
@@ -287,23 +310,32 @@ namespace Google.Datastore.V1Beta3
         /// <summary>
         /// Inserts a single entity, non-transactionally.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="Insert(Entity[])"/>.</remarks>
+        /// <remarks>This method simply delegates to <see cref="Insert(IEnumerable{Entity}, CallSettings)"/>.</remarks>
         /// <param name="entity">The entity to insert. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The key of the inserted entity.</returns>
-        public Key Insert(Entity entity) => Insert(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) })[0];
+        public Key Insert(Entity entity, CallSettings callSettings = null) =>
+            Insert(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings)[0];
         /// <summary>
         /// Inserts a collection of entities, non-transactionally.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="Insert(IEnumerable{Entity})"/>.</remarks>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="Insert(IEnumerable{Entity},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="Insert(IEnumerable{Entity},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
         /// <param name="entities">The entities to insert. Must not be null or contain null entries.</param>
         /// <returns>A collection of keys of inserted entities, in the same order as <paramref name="entities"/>.</returns>
-        public IReadOnlyList<Key> Insert(params Entity[] entities) => Insert((IEnumerable<Entity>) entities);
+        public IReadOnlyList<Key> Insert(params Entity[] entities) => Insert(entities, null);
         /// <summary>
         /// Inserts a collection of entities, non-transactionally.
         /// </summary>
         /// <param name="entities">The entities to insert. Must not be null or contain null entries.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A collection of keys of inserted entities, in the same order as <paramref name="entities"/>.</returns>
-        public virtual IReadOnlyList<Key> Insert(IEnumerable<Entity> entities)
+        public virtual IReadOnlyList<Key> Insert(IEnumerable<Entity> entities, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -311,23 +343,32 @@ namespace Google.Datastore.V1Beta3
         /// <summary>
         /// Upserts a single entity, non-transactionally.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="Upsert(Entity[])"/>.</remarks>
+        /// <remarks>This method simply delegates to <see cref="Upsert(IEnumerable{Entity}, CallSettings)"/>.</remarks>
         /// <param name="entity">The entity to upsert. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The key of the upserted entity.</returns>
-        public Key Upsert(Entity entity) => Upsert(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) })[0];
+        public Key Upsert(Entity entity, CallSettings callSettings = null) =>
+            Upsert(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings)[0];
         /// <summary>
         /// Upserts a collection of entities, non-transactionally.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="Upsert(IEnumerable{Entity})"/>.</remarks>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="Upsert(IEnumerable{Entity},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="Upsert(IEnumerable{Entity},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
         /// <param name="entities">The entities to upsert. Must not be null or contain null entries.</param>
         /// <returns>A collection of keys of upserted entities, in the same order as <paramref name="entities"/>.</returns>
-        public IReadOnlyList<Key> Upsert(params Entity[] entities) => Upsert((IEnumerable<Entity>) entities);
+        public IReadOnlyList<Key> Upsert(params Entity[] entities) => Upsert(entities, null);
         /// <summary>
         /// Upserts a collection of entities, non-transactionally.
         /// </summary>
         /// <param name="entities">The entities to upsert. Must not be null or contain null entries.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A collection of keys of upserted entities, in the same order as <paramref name="entities"/>.</returns>
-        public virtual IReadOnlyList<Key> Upsert(IEnumerable<Entity> entities)
+        public virtual IReadOnlyList<Key> Upsert(IEnumerable<Entity> entities, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -335,23 +376,32 @@ namespace Google.Datastore.V1Beta3
         /// <summary>
         /// Updates a single entity, non-transactionally.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="Update(Entity[])"/>.</remarks>
+        /// <remarks>This method simply delegates to <see cref="Update(IEnumerable{Entity},CallSettings)"/>.</remarks>
         /// <param name="entity">The entity to update. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The key of the updated entity.</returns>
-        public Key Update(Entity entity) => Update(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) })[0];
+        public Key Update(Entity entity, CallSettings callSettings = null) =>
+            Update(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings)[0];
         /// <summary>
         /// Updates a collection of entities, non-transactionally.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="Update(IEnumerable{Entity})"/>.</remarks>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="Update(IEnumerable{Entity},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="Update(IEnumerable{Entity},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
         /// <param name="entities">The entities to update. Must not be null or contain null entries.</param>
         /// <returns>A collection of keys of updated entities, in the same order as <paramref name="entities"/>.</returns>
-        public IReadOnlyList<Key> Update(params Entity[] entities) => Update((IEnumerable<Entity>) entities);
+        public IReadOnlyList<Key> Update(params Entity[] entities) => Update(entities, null);
         /// <summary>
         /// Updates a collection of entities, non-transactionally.
         /// </summary>
         /// <param name="entities">The entities to update. Must not be null or contain null entries.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A collection of keys of updated entities, in the same order as <paramref name="entities"/>.</returns>
-        public virtual IReadOnlyList<Key> Update(IEnumerable<Entity> entities)
+        public virtual IReadOnlyList<Key> Update(IEnumerable<Entity> entities, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -359,20 +409,29 @@ namespace Google.Datastore.V1Beta3
         /// <summary>
         /// Deletes a single entity, non-transactionally.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="Delete(Entity[])"/>.</remarks>
+        /// <remarks>This method simply delegates to <see cref="Delete(IEnumerable{Entity},CallSettings)"/>.</remarks>
         /// <param name="entity">The entity to delete. Must not be null.</param>
-        public void Delete(Entity entity) => Delete(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) });
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        public void Delete(Entity entity, CallSettings callSettings = null) =>
+            Delete(new[] { GaxPreconditions.CheckNotNull(entity, nameof(entity)) }, callSettings);
         /// <summary>
         /// Deletes a collection of entities, non-transactionally.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="Delete(IEnumerable{Entity})"/>.</remarks>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="Delete(IEnumerable{Entity},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="Delete(IEnumerable{Entity},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
         /// <param name="entities">The entities to delete. Must not be null or contain null entries.</param>
-        public void Delete(params Entity[] entities) => Delete((IEnumerable<Entity>) entities);
+        public void Delete(params Entity[] entities) => Delete(entities, null);
         /// <summary>
         /// Deletes a collection of entities, non-transactionally.
         /// </summary>
         /// <param name="entities">The entities to delete. Must not be null or contain null entries.</param>
-        public virtual void Delete(IEnumerable<Entity> entities)
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        public virtual void Delete(IEnumerable<Entity> entities, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -380,20 +439,29 @@ namespace Google.Datastore.V1Beta3
         /// <summary>
         /// Deletes a single key, non-transactionally.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="Delete(Key[])"/>.</remarks>
+        /// <remarks>This method simply delegates to <see cref="Delete(IEnumerable{Key},CallSettings)"/>.</remarks>
         /// <param name="key">The key to delete. Must not be null.</param>
-        public void Delete(Key key) => Delete(new[] { GaxPreconditions.CheckNotNull(key, nameof(key)) });
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        public void Delete(Key key, CallSettings callSettings = null) =>
+            Delete(new[] { GaxPreconditions.CheckNotNull(key, nameof(key)) }, callSettings);
         /// <summary>
         /// Deletes a collection of keys, non-transactionally.
         /// </summary>
-        /// <remarks>This method simply delegates to <see cref="Delete(IEnumerable{Key})"/>.</remarks>
+        /// <remarks>
+        /// <para>This method simply delegates to <see cref="Delete(IEnumerable{Key},CallSettings)"/>.</para>
+        /// <para>
+        /// Call settings are not supported on this call due to restrictions with methods containing a parameter array and optional parameters.
+        /// To specify options, create a collection or array explicitly, and call <see cref="Delete(IEnumerable{Key},CallSettings)"/>.
+        /// </para>
+        /// </remarks>
         /// <param name="keys">The keys to delete. Must not be null or contain null entries.</param>
-        public void Delete(params Key[] keys) => Delete((IEnumerable<Key>) keys);
+        public void Delete(params Key[] keys) => Delete(keys, null);
         /// <summary>
         /// Deletes a collection of keys, non-transactionally.
         /// </summary>
         /// <param name="keys">The keys to delete. Must not be null or contain null entries.</param>
-        public virtual void Delete(IEnumerable<Key> keys)
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        public virtual void Delete(IEnumerable<Key> keys, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }

--- a/src/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
@@ -1,0 +1,132 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Google.Datastore.V1Beta3.CommitRequest.Types;
+using static Google.Datastore.V1Beta3.ReadOptions.Types;
+
+namespace Google.Datastore.V1Beta3
+{
+    /// <summary>
+    /// Wrapper around <see cref="DatastoreClient"/> to provide simpler operations.
+    /// </summary>
+    /// <remarks>
+    /// This is the "default" implementation of <see cref="DatastoreDb"/>. Most client code
+    /// should refer to <see cref="DatastoreDb"/>, creating instances with
+    /// <see cref="BigqueryClient.Create(string, string, DatastoreClient)"/>. The constructor
+    /// of this class is public for the sake of constructor-based dependency injection.
+    /// </remarks>
+    public sealed class DatastoreDbImpl : DatastoreDb
+    {
+        /// <inheritdoc/>
+        public override DatastoreClient Client { get; }
+
+        /// <inheritdoc/>
+        public override string ProjectId { get; }
+
+        /// <inheritdoc/>
+        public override string NamespaceId { get; }
+
+        private readonly PartitionId _partitionId;
+
+        /// <summary>
+        /// Constructs an instance from the given project ID, namespace ID and client.
+        /// </summary>
+        /// <remarks>This constructor is primarily provided for constructor-based dependency injection.
+        /// The static <see cref="DatastoreDb.Create(string, string, DatastoreClient)"/> method is provided
+        /// for manually obtaining an instance, including automatic client creation.</remarks>
+        /// <param name="projectId">The project ID. Must not be null.</param>
+        /// <param name="namespaceId">The namespace ID. Must not be null.</param>
+        /// <param name="client">The client to use for underlying operations. Must not be null.</param>
+        public DatastoreDbImpl(string projectId, string namespaceId, DatastoreClient client) : base()
+        {
+            ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            NamespaceId = GaxPreconditions.CheckNotNull(namespaceId, nameof(namespaceId));
+            _partitionId = new PartitionId(projectId, namespaceId);
+            Client = GaxPreconditions.CheckNotNull(client, nameof(client));
+        }
+
+        /// <inheritdoc/>
+        public override KeyFactory CreateKeyFactory(string kind) => new KeyFactory(_partitionId, kind);
+
+        /// <inheritdoc/>
+        public override RunQueryResponse RunQuery(Query query, ReadConsistency? readConsistency = null) =>
+            Client.RunQuery(ProjectId, _partitionId, GetReadOptions(readConsistency), query);
+
+        /// <inheritdoc/>
+        public override RunQueryResponse RunQuery(GqlQuery query, ReadConsistency? readConsistency = null) =>
+            Client.RunQuery(ProjectId, _partitionId, GetReadOptions(readConsistency), query);
+
+        /// <inheritdoc/>
+        public override IPagedEnumerable<RunQueryResponse, Entity> RunQueryPageStream(Query query, ReadConsistency? readConsistency = null)
+        {
+            var request = new RunQueryRequest
+            {
+                ProjectId = ProjectId,
+                PartitionId = _partitionId,
+                Query = query,
+                ReadOptions = GetReadOptions(readConsistency)
+            };
+            return new PagedEnumerable<RunQueryRequest, RunQueryResponse, Entity>(Client.RunQueryApiCall, request, null);
+        }
+
+        /// <inheritdoc/>
+        public override DatastoreTransaction BeginTransaction() =>
+            new DatastoreTransaction(Client, ProjectId, Client.BeginTransaction(ProjectId).Transaction);
+
+        /// <inheritdoc/>
+        public override IReadOnlyList<Key> AllocateIds(IEnumerable<Key> keys)
+        {
+            // TODO: Validation. All keys should be non-null, and have a filled in path element
+            // until the final one, which should just have a kind. Or we could just let the server validate...
+            keys = GaxPreconditions.CheckNotNull(keys, nameof(keys)).ToList();
+            var response = Client.AllocateIds(ProjectId, keys);
+            return response.Keys.ToList();
+        }
+
+        /// <inheritdoc/>
+        public override IReadOnlyList<Entity> Lookup(IEnumerable<Key> keys, ReadConsistency? readConsistency = null)
+            => LookupImpl(Client, ProjectId, GetReadOptions(readConsistency), keys);
+
+        // Non-transactional mutations
+
+        /// <inheritdoc/>
+        public override IReadOnlyList<Key> Insert(IEnumerable<Entity> entities) => Commit(entities, e => e.ToInsert(), nameof(entities));
+
+        /// <inheritdoc/>
+        public override IReadOnlyList<Key> Upsert(IEnumerable<Entity> entities) => Commit(entities, e => e.ToUpsert(), nameof(entities));
+
+        /// <inheritdoc/>
+        public override IReadOnlyList<Key> Update(IEnumerable<Entity> entities) => Commit(entities, e => e.ToUpdate(), nameof(entities));
+
+        /// <inheritdoc/>
+        public override void Delete(IEnumerable<Entity> entities) => Commit(entities, e => e.ToDelete(), nameof(entities));
+
+        /// <inheritdoc/>
+        public override void Delete(IEnumerable<Key> keys) => Commit(keys, e => e.ToDelete(), nameof(keys));
+
+        private IReadOnlyList<Key> Commit<T>(IEnumerable<T> values, Func<T, Mutation> conversion, string parameterName)
+        {
+            // TODO: Validation
+            var response = Client.Commit(ProjectId, Mode.NonTransactional, values.Select(conversion));
+            return response.MutationResults.Select(mr => mr.Key).ToList();
+        }
+
+        private static ReadOptions GetReadOptions(ReadConsistency? readConsistency) =>
+            readConsistency == null ? null : new ReadOptions { ReadConsistency = readConsistency.Value };
+    }
+}

--- a/src/Google.Datastore.V1Beta3/DatastoreTransaction.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreTransaction.cs
@@ -56,9 +56,9 @@ namespace Google.Datastore.V1Beta3
             _active = true; 
         }
 
-        public Entity Lookup(Key key) => DatastoreDb.LookupImpl(_client, _projectId, _readOptions, new[] { key })[0]; 
+        public Entity Lookup(Key key) => DatastoreDb.LookupImpl(_client, _projectId, _readOptions, new[] { key }, null)[0]; 
         public IReadOnlyList<Entity> Lookup(params Key[] keys) => Lookup((IEnumerable<Key>)keys);
-        public IReadOnlyList<Entity> Lookup(IEnumerable<Key> keys) => DatastoreDb.LookupImpl(_client, _projectId, _readOptions, keys);
+        public IReadOnlyList<Entity> Lookup(IEnumerable<Key> keys) => DatastoreDb.LookupImpl(_client, _projectId, _readOptions, keys, null);
 
         /// <summary>
         /// Runs the specified query in this transaction.

--- a/src/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.xproj
+++ b/src/Google.Datastore.V1Beta3/Google.Datastore.V1Beta3.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>4da2e647-3a2b-448b-b1f5-034750bba5b6</ProjectGuid>
     <RootNamespace>Google.Datastore.V1Beta3</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Google.Logging.Type/Google.Logging.Type.xproj
+++ b/src/Google.Logging.Type/Google.Logging.Type.xproj
@@ -9,9 +9,8 @@
     <ProjectGuid>a8382b79-21e7-4aad-aff8-ab8707958128</ProjectGuid>
     <RootNamespace>Google.Logging.Type</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/Google.Logging.V2/Google.Logging.V2.xproj
+++ b/src/Google.Logging.V2/Google.Logging.V2.xproj
@@ -9,9 +9,8 @@
     <ProjectGuid>35b8d21d-0253-417f-b171-06bf70aa9485</ProjectGuid>
     <RootNamespace>Google.Logging.V2</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/Google.Pubsub.V1/Google.Pubsub.V1.xproj
+++ b/src/Google.Pubsub.V1/Google.Pubsub.V1.xproj
@@ -9,9 +9,8 @@
     <ProjectGuid>768566bc-8f77-4f7c-8a15-f8a11308b74b</ProjectGuid>
     <RootNamespace>Google.Pubsub.V1</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/Google.Storage.V1/Google.Storage.V1.xproj
+++ b/src/Google.Storage.V1/Google.Storage.V1.xproj
@@ -4,15 +4,13 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>e8814844-5fa9-4f2b-aead-e7ce427de48a</ProjectGuid>
     <RootNamespace>Google.Storage.V1</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/test/Google.Bigquery.V2.IntegrationTests/Google.Bigquery.V2.IntegrationTests.xproj
+++ b/test/Google.Bigquery.V2.IntegrationTests/Google.Bigquery.V2.IntegrationTests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>cbd350ee-3b27-4129-8999-1815decf9e66</ProjectGuid>
     <RootNamespace>Google.Bigquery.V2.IntegrationTests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/Google.Datastore.V1Beta3.Tests/Google.Datastore.V1Beta3.Tests.xproj
+++ b/test/Google.Datastore.V1Beta3.Tests/Google.Datastore.V1Beta3.Tests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>fd2fad82-6719-4e1b-9291-7f8cdf819a3b</ProjectGuid>
     <RootNamespace>Google.Datastore.V1Beta3.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/Google.Storage.V1.IntegrationTests/Google.Storage.V1.IntegrationTests.xproj
+++ b/test/Google.Storage.V1.IntegrationTests/Google.Storage.V1.IntegrationTests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>077ddb17-cf46-4285-8853-d9ae576320f5</ProjectGuid>
     <RootNamespace>Google.Storage.V1.IntegrationTests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/Google.Storage.V1.Tests/Google.Storage.V1.Tests.xproj
+++ b/test/Google.Storage.V1.Tests/Google.Storage.V1.Tests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>c9b4d3e8-47c4-4498-beff-276060d1ea13</ProjectGuid>
     <RootNamespace>Google.Storage.V1.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/tools/Google.GCloud.Tools.GenerateSnippetMarkdown/Google.GCloud.Tools.GenerateSnippetMarkdown.xproj
+++ b/tools/Google.GCloud.Tools.GenerateSnippetMarkdown/Google.GCloud.Tools.GenerateSnippetMarkdown.xproj
@@ -9,9 +9,8 @@
     <ProjectGuid>656e050f-d24b-4cbe-9771-b3ef472342c0</ProjectGuid>
     <RootNamespace>Google.GCloud.Tools.GenerateSnippetMarkdown</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>


### PR DESCRIPTION
Suggest reviewing one commit at a time.

After this, we still want to:

- Do similar things to DatastoreTransaction (I suspect)
- *Maybe* add async overloads taking a CancellationToken, although we can't do this universally - for methods that already have an optional parameter, we can't add a required parameter at the end.

I'm not sure why we've got all these xproj changes, but I suspect they'll come back even if I get rid of them manually now - let me know if you'd like me to try to split them out into a separate PR.
