### PR TITLE
Remove Microsoft copyright from footer

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -24,7 +24,8 @@
     ],
     "globalMetadata": {
       "_appTitle": "Google Cloud APIs",
-      "_disableContribution": true
+      "_disableContribution": true,
+      "_appFooter": " "
     },
     "overwrite": [ "extra/*.md", "obj/snippets/*.md" ],
     "dest": "_site"


### PR DESCRIPTION
I haven't replaced it with a Google copyright notice, as it looks like none of
our other documentation has a copyright in the page.

The use of a space is deliberate here - an empty string didn't make any difference, i.e.
the original Microsoft copyright was still shown.

This fixes issue #167.