### PR TITLE
Use the new page-streaming implementation

### DIFF
--- a/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreDbSnippets.cs
+++ b/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreDbSnippets.cs
@@ -85,21 +85,21 @@ namespace Google.Datastore.V1Beta3.Snippets
             string projectId = _fixture.ProjectId;
             string namespaceId = _fixture.NamespaceId;
 
-            // Snippet: RunQueryPageStream(Query,*,*)
+            // Snippet: RunQuery(Query,*,*)
             DatastoreDb db = DatastoreDb.Create(projectId, namespaceId);
             Query query = new Query("book")
             {
                 Filter = Filter.Equal("author", "Jane Austen")
             };
-            IPagedEnumerable<RunQueryResponse, Entity> results = db.RunQueryPageStream(query);
-            foreach (Entity entity in results.Flatten())
+            IPagedEnumerable<RunQueryResponse, Entity> results = db.RunQuery(query);
+            foreach (Entity entity in results)
             {
                 Console.WriteLine(entity);
             }
             // End snippet
 
             // This will run the query again, admittedly...
-            List<Entity> entities = results.Flatten().ToList();
+            List<Entity> entities = results.ToList();
             Assert.Equal(1, entities.Count);
             Entity book = entities[0];
             Assert.Equal("Jane Austen", (string)book["author"]);
@@ -112,21 +112,21 @@ namespace Google.Datastore.V1Beta3.Snippets
             string projectId = _fixture.ProjectId;
             string namespaceId = _fixture.NamespaceId;
 
-            // Snippet: RunQueryPageStreamAsync(Query,*,*)
+            // Snippet: RunQueryAsync(Query,*,*)
             DatastoreDb db = DatastoreDb.Create(projectId, namespaceId);
             Query query = new Query("book")
             {
                 Filter = Filter.Equal("author", "Jane Austen")
             };
-            IPagedAsyncEnumerable<RunQueryResponse, Entity> results = db.RunQueryPageStreamAsync(query);
-            await results.Flatten().ForEachAsync(entity =>
+            IPagedAsyncEnumerable<RunQueryResponse, Entity> results = db.RunQueryAsync(query);
+            await results.ForEachAsync(entity =>
             {
                 Console.WriteLine(entity);
             });
             // End snippet
 
             // This will run the query again, admittedly...
-            List<Entity> entities = await results.Flatten().ToList();
+            List<Entity> entities = await results.ToList();
             Assert.Equal(1, entities.Count);
             Entity book = entities[0];
             Assert.Equal("Jane Austen", (string)book["author"]);
@@ -139,7 +139,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             string projectId = _fixture.ProjectId;
             string namespaceId = _fixture.NamespaceId;
 
-            // Snippet: RunQuery(GqlQuery,*,*)
+            // Snippet: RunQuerySingleCall(GqlQuery,*,*)
             DatastoreDb db = DatastoreDb.Create(projectId, namespaceId);
             GqlQuery gqlQuery = new GqlQuery
             {
@@ -147,7 +147,7 @@ namespace Google.Datastore.V1Beta3.Snippets
                 NamedBindings = { { "author", new GqlQueryParameter { Value = "Jane Austen" } } },
             };
             // Note: no page streaming for GQL yet.
-            RunQueryResponse response = db.RunQuery(gqlQuery);
+            RunQueryResponse response = db.RunQuerySingleCall(gqlQuery);
             foreach (EntityResult result in response.Batch.EntityResults)
             {
                 Console.WriteLine(result.Entity);
@@ -166,7 +166,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             string projectId = _fixture.ProjectId;
             string namespaceId = _fixture.NamespaceId;
 
-            // Snippet: RunQueryAsync(GqlQuery,*,*)
+            // Snippet: RunQuerySingleCallAsync(GqlQuery,*,*)
             DatastoreDb db = DatastoreDb.Create(projectId, namespaceId);
             GqlQuery gqlQuery = new GqlQuery
             {
@@ -174,7 +174,7 @@ namespace Google.Datastore.V1Beta3.Snippets
                 NamedBindings = { { "author", new GqlQueryParameter { Value = "Jane Austen" } } },
             };
             // Note: no page streaming for GQL yet.
-            RunQueryResponse response = await db.RunQueryAsync(gqlQuery);
+            RunQueryResponse response = await db.RunQuerySingleCallAsync(gqlQuery);
             foreach (EntityResult result in response.Batch.EntityResults)
             {
                 Console.WriteLine(result.Entity);
@@ -343,7 +343,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             // Sample: NamespaceQuery
             DatastoreDb db = DatastoreDb.Create(projectId, "");
             Query query = new Query(DatastoreConstants.NamespaceKind);
-            foreach (Entity entity in db.RunQueryPageStream(query).Flatten())
+            foreach (Entity entity in db.RunQuery(query))
             {
                 Console.WriteLine(entity.Key.Path.Last().Name);
             }
@@ -359,7 +359,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             // Sample: KindQuery
             DatastoreDb db = DatastoreDb.Create(projectId, namespaceId);
             Query query = new Query(DatastoreConstants.KindKind);
-            foreach (Entity entity in db.RunQueryPageStream(query).Flatten())
+            foreach (Entity entity in db.RunQuery(query))
             {
                 Console.WriteLine(entity.Key.Path.Last().Name);
             }
@@ -375,7 +375,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             // Sample: PropertyQuery
             DatastoreDb db = DatastoreDb.Create(projectId, namespaceId);
             Query query = new Query(DatastoreConstants.PropertyKind);
-            foreach (Entity entity in db.RunQueryPageStream(query).Flatten())
+            foreach (Entity entity in db.RunQuery(query))
             {
                 Console.WriteLine(entity.Key.Path.Last().Name);
             }
@@ -563,7 +563,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             };
 
             DatastoreDb db = DatastoreDb.Create(projectId, namespaceId);            
-            foreach (Entity entity in db.RunQueryPageStream(query).Flatten())
+            foreach (Entity entity in db.RunQuery(query))
             {
                 Console.WriteLine((string)entity["description"]);
             }
@@ -643,7 +643,7 @@ namespace Google.Datastore.V1Beta3.Snippets
                 Projection = { "priority", "percentage_complete" }
             };
             DatastoreDb db = DatastoreDb.Create(projectId, namespaceId);
-            foreach (Entity entity in db.RunQueryPageStream(query).Flatten())
+            foreach (Entity entity in db.RunQuery(query))
             {
                 Console.WriteLine($"{(int)entity["priority"]}: {(double?)entity["percentage_complete"]}");
             }            
@@ -707,7 +707,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             Query query = new Query("Task") { Limit = pageSize, StartCursor = pageCursor ?? ByteString.Empty };
             DatastoreDb db = DatastoreDb.Create(projectId, namespaceId);
 
-            RunQueryResponse response = db.RunQuery(query, ReadConsistency.Eventual);
+            RunQueryResponse response = db.RunQuerySingleCall(query, ReadConsistency.Eventual);
             foreach (EntityResult result in response.Batch.EntityResults)
             {
                 Entity entity = result.Entity;

--- a/snippets/Google.Pubsub.V1.Snippets/PublisherClientSnippets.cs
+++ b/snippets/Google.Pubsub.V1.Snippets/PublisherClientSnippets.cs
@@ -34,17 +34,17 @@ namespace Google.Pubsub.V1.Snippets
         }
 
         [Fact]
-        public void ListTopicsPageStream()
+        public void ListTopics()
         {
             string projectId = _fixture.ProjectId;
 
-            // Snippet: ListTopicsPageStream
+            // Snippet: ListTopics
             PublisherClient client = PublisherClient.Create();
 
             // Alternative: use a known project resource name:
             // "projects/{PROJECT_ID}"
             string projectName = PublisherClient.FormatProjectName(projectId);
-            foreach (Topic topic in client.ListTopicsPageStream(projectName).Flatten())
+            foreach (Topic topic in client.ListTopics(projectName))
             {
                 Console.WriteLine(topic.Name);
             }
@@ -52,17 +52,17 @@ namespace Google.Pubsub.V1.Snippets
         }
 
         [Fact]
-        public async Task ListTopicsPageStreamAsync()
+        public async Task ListTopicsAsync()
         {
             string projectId = _fixture.ProjectId;
 
-            // Snippet: ListTopicsPageStreamAsync
+            // Snippet: ListTopicsAsync
             PublisherClient client = PublisherClient.Create();
 
             // Alternative: use a known project resource name:
             // "projects/{PROJECT_ID}"
             string projectName = PublisherClient.FormatProjectName(projectId);
-            IAsyncEnumerable<Topic> topics = client.ListTopicsPageStreamAsync(projectName).Flatten();
+            IAsyncEnumerable<Topic> topics = client.ListTopicsAsync(projectName);
             await topics.ForEachAsync(topic =>
             {
                 Console.WriteLine(topic.Name);

--- a/snippets/Google.Pubsub.V1.Snippets/PubsubSnippetFixture.cs
+++ b/snippets/Google.Pubsub.V1.Snippets/PubsubSnippetFixture.cs
@@ -60,8 +60,7 @@ namespace Google.Pubsub.V1.Snippets
         public void Dispose()
         {
             var subscriber = SubscriberClient.Create();
-            var subscriptions = subscriber.ListSubscriptionsPageStream(SubscriberClient.FormatProjectName(ProjectId))
-                .Flatten()
+            var subscriptions = subscriber.ListSubscriptions(SubscriberClient.FormatProjectName(ProjectId))
                 .Where(sub => SubscriberClient.SubscriptionTemplate.ParseName(sub.Name)[1].StartsWith(TopicPrefix))
                 .ToList();
             foreach (var sub in subscriptions)
@@ -70,8 +69,7 @@ namespace Google.Pubsub.V1.Snippets
             }
 
             var publisher = PublisherClient.Create();
-            var topics = publisher.ListTopicsPageStream(PublisherClient.FormatProjectName(ProjectId))
-                .Flatten()
+            var topics = publisher.ListTopics(PublisherClient.FormatProjectName(ProjectId))
                 .Where(topic => PublisherClient.TopicTemplate.ParseName(topic.Name)[1].StartsWith(TopicPrefix))
                 .ToList();
             foreach (var topic in topics)

--- a/snippets/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.cs
+++ b/snippets/Google.Pubsub.V1.Snippets/SubscriberClientSnippets.cs
@@ -92,13 +92,13 @@ namespace Google.Pubsub.V1.Snippets
         {
             string projectId = _fixture.ProjectId;
 
-            // Snippet: ListSubscriptionsPageStream
+            // Snippet: ListSubscriptions
             SubscriberClient client = SubscriberClient.Create();
 
             // Alternative: use a known project resource name:
             // "projects/{PROJECT_ID}"
             string projectName = SubscriberClient.FormatProjectName(projectId);
-            foreach (Subscription subscription in client.ListSubscriptionsPageStream(projectName).Flatten())
+            foreach (Subscription subscription in client.ListSubscriptions(projectName))
             {
                 Console.WriteLine($"{subscription.Name} subscribed to {subscription.Topic}");
             }
@@ -110,13 +110,13 @@ namespace Google.Pubsub.V1.Snippets
         {
             string projectId = _fixture.ProjectId;
 
-            // Snippet: ListSubscriptionsPageStreamAsync
+            // Snippet: ListSubscriptionsAsync
             SubscriberClient client = SubscriberClient.Create();
 
             // Alternative: use a known project resource name:
             // "projects/{PROJECT_ID}"
             string projectName = SubscriberClient.FormatProjectName(projectId);
-            IAsyncEnumerable<Subscription> subscriptions = client.ListSubscriptionsPageStreamAsync(projectName).Flatten();
+            IAsyncEnumerable<Subscription> subscriptions = client.ListSubscriptionsAsync(projectName);
             await subscriptions.ForEachAsync(subscription =>
             {
                 Console.WriteLine($"{subscription.Name} subscribed to {subscription.Topic}");

--- a/src/Google.Datastore.V1Beta3/DatastoreDb.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreDb.cs
@@ -142,13 +142,13 @@ namespace Google.Datastore.V1Beta3
         /// using this object's partition ID and the specified read consistency, not in a transaction.
         /// </summary>
         /// <remarks>
-        /// To automatically stream pages of results, use <see cref="RunQueryPageStream(Query, ReadConsistency?, CallSettings)"/>.
+        /// To automatically stream pages of results, use <see cref="RunQuery(Query, ReadConsistency?, CallSettings)"/>.
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">The desired read consistency of the query, or null to use the default.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The response for the given query operation.</returns>
-        public virtual RunQueryResponse RunQuery(Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        public virtual RunQueryResponse RunQuerySingleCall(Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -158,13 +158,13 @@ namespace Google.Datastore.V1Beta3
         /// using this object's partition ID and the specified read consistency, not in a transaction.
         /// </summary>
         /// <remarks>
-        /// To automatically stream pages of results, use <see cref="RunQueryPageStreamAsync(Query, ReadConsistency?, CallSettings)"/>.
+        /// To automatically stream pages of results, use <see cref="RunQueryAsync(Query, ReadConsistency?, CallSettings)"/>.
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">The desired read consistency of the query, or null to use the default.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The response for the given query operation.</returns>
-        public virtual Task<RunQueryResponse> RunQueryAsync(Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        public virtual Task<RunQueryResponse> RunQuerySingleCallAsync(Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -179,7 +179,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="readConsistency">The desired read consistency of the query, or null to use the default.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The response for the given query operation.</returns>
-        public virtual RunQueryResponse RunQuery(GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        public virtual RunQueryResponse RunQuerySingleCall(GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -192,7 +192,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="readConsistency">The desired read consistency of the query, or null to use the default.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>The response for the given query operation.</returns>
-        public virtual Task<RunQueryResponse> RunQueryAsync(GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        public virtual Task<RunQueryResponse> RunQuerySingleCallAsync(GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -210,7 +210,7 @@ namespace Google.Datastore.V1Beta3
         /// the default.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A sequence of pages of entities.</returns>
-        public virtual IPagedEnumerable<RunQueryResponse, Entity> RunQueryPageStream(
+        public virtual IPagedEnumerable<RunQueryResponse, Entity> RunQuery(
             Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
@@ -229,7 +229,7 @@ namespace Google.Datastore.V1Beta3
         /// the default.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A sequence of pages of entities.</returns>
-        public virtual IPagedAsyncEnumerable<RunQueryResponse, Entity> RunQueryPageStreamAsync(
+        public virtual IPagedAsyncEnumerable<RunQueryResponse, Entity> RunQueryAsync(
             Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();

--- a/src/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
@@ -65,31 +65,31 @@ namespace Google.Datastore.V1Beta3
         public override KeyFactory CreateKeyFactory(string kind) => new KeyFactory(_partitionId, kind);
 
         /// <inheritdoc/>
-        public override RunQueryResponse RunQuery(
+        public override RunQueryResponse RunQuerySingleCall(
             Query query, 
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null) =>
             Client.RunQuery(ProjectId, _partitionId, GetReadOptions(readConsistency), query, callSettings);
 
         /// <inheritdoc/>
-        public override Task<RunQueryResponse> RunQueryAsync(
+        public override Task<RunQueryResponse> RunQuerySingleCallAsync(
             Query query,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null) =>
             Client.RunQueryAsync(ProjectId, _partitionId, GetReadOptions(readConsistency), query, callSettings);
 
         /// <inheritdoc/>
-        public override RunQueryResponse RunQuery(
+        public override RunQueryResponse RunQuerySingleCall(
             GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null) =>
             Client.RunQuery(ProjectId, _partitionId, GetReadOptions(readConsistency), query, callSettings);
 
         /// <inheritdoc/>
-        public override Task<RunQueryResponse> RunQueryAsync(
+        public override Task<RunQueryResponse> RunQuerySingleCallAsync(
             GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null) =>
             Client.RunQueryAsync(ProjectId, _partitionId, GetReadOptions(readConsistency), query, callSettings);
 
         /// <inheritdoc/>
-        public override IPagedEnumerable<RunQueryResponse, Entity> RunQueryPageStream(
+        public override IPagedEnumerable<RunQueryResponse, Entity> RunQuery(
             Query query,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)
@@ -105,7 +105,7 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <inheritdoc/>
-        public override IPagedAsyncEnumerable<RunQueryResponse, Entity> RunQueryPageStreamAsync(
+        public override IPagedAsyncEnumerable<RunQueryResponse, Entity> RunQueryAsync(
             Query query,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)

--- a/src/Google.Datastore.V1Beta3/project.json
+++ b/src/Google.Datastore.V1Beta3/project.json
@@ -14,7 +14,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax": "0.1.0-CI00051",
+    "Google.Api.Gax": "0.1.0-CI00055",
     "Google.Apis.Auth": "1.13.0",
     "Google.Protobuf": "3.0.0-beta3",
     "Grpc.Auth": "0.14.0",

--- a/src/Google.Logging.Type/project.json
+++ b/src/Google.Logging.Type/project.json
@@ -14,7 +14,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax": "0.1.0-CI00051",
+    "Google.Api.Gax": "0.1.0-CI00055",
     "Google.Protobuf": "3.0.0-beta3"
   },
 

--- a/src/Google.Logging.V2/ConfigServiceV2Client.cs
+++ b/src/Google.Logging.V2/ConfigServiceV2Client.cs
@@ -137,11 +137,11 @@ namespace Google.Logging.V2
 
         /// <summary>
         /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
-        /// <see cref="ConfigServiceV2Client.ListSinksPageStream"/> and <see cref="ConfigServiceV2Client.ListSinksPageStreamAsync"/>.
+        /// <see cref="ConfigServiceV2Client.ListSinks"/> and <see cref="ConfigServiceV2Client.ListSinksAsync"/>.
         /// </summary>
         /// <remarks>
-        /// The default <see cref="ConfigServiceV2Client.ListSinksPageStream"/> and
-        /// <see cref="ConfigServiceV2Client.ListSinksPageStreamAsync"/> <see cref="RetrySettings"/> are:
+        /// The default <see cref="ConfigServiceV2Client.ListSinks"/> and
+        /// <see cref="ConfigServiceV2Client.ListSinksAsync"/> <see cref="RetrySettings"/> are:
         /// <list type="bullet">
         /// <item><description>Initial retry delay: 100 milliseconds</description></item>
         /// <item><description>Retry delay multiplier: 1.2</description></item>
@@ -452,7 +452,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of LogSink items.</returns>
-        public virtual IPagedAsyncEnumerable<ListSinksResponse, LogSink> ListSinksPageStreamAsync(
+        public virtual IPagedAsyncEnumerable<ListSinksResponse, LogSink> ListSinksAsync(
             string parent,
             string pageToken = null,
             int? pageSize = null,
@@ -475,7 +475,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of LogSink items.</returns>
-        public virtual IPagedEnumerable<ListSinksResponse, LogSink> ListSinksPageStream(
+        public virtual IPagedEnumerable<ListSinksResponse, LogSink> ListSinks(
             string parent,
             string pageToken = null,
             int? pageSize = null,
@@ -769,7 +769,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of LogSink items.</returns>
-        public override IPagedAsyncEnumerable<ListSinksResponse, LogSink> ListSinksPageStreamAsync(
+        public override IPagedAsyncEnumerable<ListSinksResponse, LogSink> ListSinksAsync(
             string parent,
             string pageToken = null,
             int? pageSize = null,
@@ -797,7 +797,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of LogSink items.</returns>
-        public override IPagedEnumerable<ListSinksResponse, LogSink> ListSinksPageStream(
+        public override IPagedEnumerable<ListSinksResponse, LogSink> ListSinks(
             string parent,
             string pageToken = null,
             int? pageSize = null,

--- a/src/Google.Logging.V2/LoggingServiceV2Client.cs
+++ b/src/Google.Logging.V2/LoggingServiceV2Client.cs
@@ -239,11 +239,11 @@ namespace Google.Logging.V2
 
         /// <summary>
         /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
-        /// <see cref="LoggingServiceV2Client.ListLogEntriesPageStream"/> and <see cref="LoggingServiceV2Client.ListLogEntriesPageStreamAsync"/>.
+        /// <see cref="LoggingServiceV2Client.ListLogEntries"/> and <see cref="LoggingServiceV2Client.ListLogEntriesAsync"/>.
         /// </summary>
         /// <remarks>
-        /// The default <see cref="LoggingServiceV2Client.ListLogEntriesPageStream"/> and
-        /// <see cref="LoggingServiceV2Client.ListLogEntriesPageStreamAsync"/> <see cref="RetrySettings"/> are:
+        /// The default <see cref="LoggingServiceV2Client.ListLogEntries"/> and
+        /// <see cref="LoggingServiceV2Client.ListLogEntriesAsync"/> <see cref="RetrySettings"/> are:
         /// <list type="bullet">
         /// <item><description>Initial retry delay: 100 milliseconds</description></item>
         /// <item><description>Retry delay multiplier: 1.2</description></item>
@@ -612,7 +612,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of LogEntry items.</returns>
-        public virtual IPagedAsyncEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntriesPageStreamAsync(
+        public virtual IPagedAsyncEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntriesAsync(
             IEnumerable<string> projectIds,
             string filter,
             string orderBy,
@@ -653,7 +653,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of LogEntry items.</returns>
-        public virtual IPagedEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntriesPageStream(
+        public virtual IPagedEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntries(
             IEnumerable<string> projectIds,
             string filter,
             string orderBy,
@@ -846,7 +846,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of LogEntry items.</returns>
-        public override IPagedAsyncEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntriesPageStreamAsync(
+        public override IPagedAsyncEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntriesAsync(
             IEnumerable<string> projectIds,
             string filter,
             string orderBy,
@@ -894,7 +894,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of LogEntry items.</returns>
-        public override IPagedEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntriesPageStream(
+        public override IPagedEnumerable<ListLogEntriesResponse, LogEntry> ListLogEntries(
             IEnumerable<string> projectIds,
             string filter,
             string orderBy,

--- a/src/Google.Logging.V2/MetricsServiceV2Client.cs
+++ b/src/Google.Logging.V2/MetricsServiceV2Client.cs
@@ -137,11 +137,11 @@ namespace Google.Logging.V2
 
         /// <summary>
         /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
-        /// <see cref="MetricsServiceV2Client.ListLogMetricsPageStream"/> and <see cref="MetricsServiceV2Client.ListLogMetricsPageStreamAsync"/>.
+        /// <see cref="MetricsServiceV2Client.ListLogMetrics"/> and <see cref="MetricsServiceV2Client.ListLogMetricsAsync"/>.
         /// </summary>
         /// <remarks>
-        /// The default <see cref="MetricsServiceV2Client.ListLogMetricsPageStream"/> and
-        /// <see cref="MetricsServiceV2Client.ListLogMetricsPageStreamAsync"/> <see cref="RetrySettings"/> are:
+        /// The default <see cref="MetricsServiceV2Client.ListLogMetrics"/> and
+        /// <see cref="MetricsServiceV2Client.ListLogMetricsAsync"/> <see cref="RetrySettings"/> are:
         /// <list type="bullet">
         /// <item><description>Initial retry delay: 100 milliseconds</description></item>
         /// <item><description>Retry delay multiplier: 1.2</description></item>
@@ -452,7 +452,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of LogMetric items.</returns>
-        public virtual IPagedAsyncEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetricsPageStreamAsync(
+        public virtual IPagedAsyncEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetricsAsync(
             string parent,
             string pageToken = null,
             int? pageSize = null,
@@ -475,7 +475,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of LogMetric items.</returns>
-        public virtual IPagedEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetricsPageStream(
+        public virtual IPagedEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetrics(
             string parent,
             string pageToken = null,
             int? pageSize = null,
@@ -769,7 +769,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of LogMetric items.</returns>
-        public override IPagedAsyncEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetricsPageStreamAsync(
+        public override IPagedAsyncEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetricsAsync(
             string parent,
             string pageToken = null,
             int? pageSize = null,
@@ -797,7 +797,7 @@ namespace Google.Logging.V2
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of LogMetric items.</returns>
-        public override IPagedEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetricsPageStream(
+        public override IPagedEnumerable<ListLogMetricsResponse, LogMetric> ListLogMetrics(
             string parent,
             string pageToken = null,
             int? pageSize = null,

--- a/src/Google.Logging.V2/project.json
+++ b/src/Google.Logging.V2/project.json
@@ -14,7 +14,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax": "0.1.0-CI00051",
+    "Google.Api.Gax": "0.1.0-CI00055",
     "Google.Apis.Auth": "1.13.0",
     "Google.Logging.Type":  "",
     "Google.Protobuf": "3.0.0-beta3",

--- a/src/Google.Pubsub.V1/PublisherClient.cs
+++ b/src/Google.Pubsub.V1/PublisherClient.cs
@@ -289,11 +289,11 @@ namespace Google.Pubsub.V1
 
         /// <summary>
         /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
-        /// <see cref="PublisherClient.ListTopicsPageStream"/> and <see cref="PublisherClient.ListTopicsPageStreamAsync"/>.
+        /// <see cref="PublisherClient.ListTopics"/> and <see cref="PublisherClient.ListTopicsAsync"/>.
         /// </summary>
         /// <remarks>
-        /// The default <see cref="PublisherClient.ListTopicsPageStream"/> and
-        /// <see cref="PublisherClient.ListTopicsPageStreamAsync"/> <see cref="RetrySettings"/> are:
+        /// The default <see cref="PublisherClient.ListTopics"/> and
+        /// <see cref="PublisherClient.ListTopicsAsync"/> <see cref="RetrySettings"/> are:
         /// <list type="bullet">
         /// <item><description>Initial retry delay: 100 milliseconds</description></item>
         /// <item><description>Retry delay multiplier: 1.3</description></item>
@@ -322,11 +322,11 @@ namespace Google.Pubsub.V1
 
         /// <summary>
         /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
-        /// <see cref="PublisherClient.ListTopicSubscriptionsPageStream"/> and <see cref="PublisherClient.ListTopicSubscriptionsPageStreamAsync"/>.
+        /// <see cref="PublisherClient.ListTopicSubscriptions"/> and <see cref="PublisherClient.ListTopicSubscriptionsAsync"/>.
         /// </summary>
         /// <remarks>
-        /// The default <see cref="PublisherClient.ListTopicSubscriptionsPageStream"/> and
-        /// <see cref="PublisherClient.ListTopicSubscriptionsPageStreamAsync"/> <see cref="RetrySettings"/> are:
+        /// The default <see cref="PublisherClient.ListTopicSubscriptions"/> and
+        /// <see cref="PublisherClient.ListTopicSubscriptionsAsync"/> <see cref="RetrySettings"/> are:
         /// <list type="bullet">
         /// <item><description>Initial retry delay: 100 milliseconds</description></item>
         /// <item><description>Retry delay multiplier: 1.3</description></item>
@@ -679,7 +679,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of Topic items.</returns>
-        public virtual IPagedAsyncEnumerable<ListTopicsResponse, Topic> ListTopicsPageStreamAsync(
+        public virtual IPagedAsyncEnumerable<ListTopicsResponse, Topic> ListTopicsAsync(
             string project,
             string pageToken = null,
             int? pageSize = null,
@@ -699,7 +699,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of Topic items.</returns>
-        public virtual IPagedEnumerable<ListTopicsResponse, Topic> ListTopicsPageStream(
+        public virtual IPagedEnumerable<ListTopicsResponse, Topic> ListTopics(
             string project,
             string pageToken = null,
             int? pageSize = null,
@@ -719,7 +719,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of string items.</returns>
-        public virtual IPagedAsyncEnumerable<ListTopicSubscriptionsResponse, string> ListTopicSubscriptionsPageStreamAsync(
+        public virtual IPagedAsyncEnumerable<ListTopicSubscriptionsResponse, string> ListTopicSubscriptionsAsync(
             string topic,
             string pageToken = null,
             int? pageSize = null,
@@ -739,7 +739,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of string items.</returns>
-        public virtual IPagedEnumerable<ListTopicSubscriptionsResponse, string> ListTopicSubscriptionsPageStream(
+        public virtual IPagedEnumerable<ListTopicSubscriptionsResponse, string> ListTopicSubscriptions(
             string topic,
             string pageToken = null,
             int? pageSize = null,
@@ -956,7 +956,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of Topic items.</returns>
-        public override IPagedAsyncEnumerable<ListTopicsResponse, Topic> ListTopicsPageStreamAsync(
+        public override IPagedAsyncEnumerable<ListTopicsResponse, Topic> ListTopicsAsync(
             string project,
             string pageToken = null,
             int? pageSize = null,
@@ -981,7 +981,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of Topic items.</returns>
-        public override IPagedEnumerable<ListTopicsResponse, Topic> ListTopicsPageStream(
+        public override IPagedEnumerable<ListTopicsResponse, Topic> ListTopics(
             string project,
             string pageToken = null,
             int? pageSize = null,
@@ -1006,7 +1006,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of string items.</returns>
-        public override IPagedAsyncEnumerable<ListTopicSubscriptionsResponse, string> ListTopicSubscriptionsPageStreamAsync(
+        public override IPagedAsyncEnumerable<ListTopicSubscriptionsResponse, string> ListTopicSubscriptionsAsync(
             string topic,
             string pageToken = null,
             int? pageSize = null,
@@ -1031,7 +1031,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of string items.</returns>
-        public override IPagedEnumerable<ListTopicSubscriptionsResponse, string> ListTopicSubscriptionsPageStream(
+        public override IPagedEnumerable<ListTopicSubscriptionsResponse, string> ListTopicSubscriptions(
             string topic,
             string pageToken = null,
             int? pageSize = null,

--- a/src/Google.Pubsub.V1/SubscriberClient.cs
+++ b/src/Google.Pubsub.V1/SubscriberClient.cs
@@ -244,11 +244,11 @@ namespace Google.Pubsub.V1
 
         /// <summary>
         /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
-        /// <see cref="SubscriberClient.ListSubscriptionsPageStream"/> and <see cref="SubscriberClient.ListSubscriptionsPageStreamAsync"/>.
+        /// <see cref="SubscriberClient.ListSubscriptions"/> and <see cref="SubscriberClient.ListSubscriptionsAsync"/>.
         /// </summary>
         /// <remarks>
-        /// The default <see cref="SubscriberClient.ListSubscriptionsPageStream"/> and
-        /// <see cref="SubscriberClient.ListSubscriptionsPageStreamAsync"/> <see cref="RetrySettings"/> are:
+        /// The default <see cref="SubscriberClient.ListSubscriptions"/> and
+        /// <see cref="SubscriberClient.ListSubscriptionsAsync"/> <see cref="RetrySettings"/> are:
         /// <list type="bullet">
         /// <item><description>Initial retry delay: 100 milliseconds</description></item>
         /// <item><description>Retry delay multiplier: 1.3</description></item>
@@ -812,7 +812,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of Subscription items.</returns>
-        public virtual IPagedAsyncEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptionsPageStreamAsync(
+        public virtual IPagedAsyncEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptionsAsync(
             string project,
             string pageToken = null,
             int? pageSize = null,
@@ -832,7 +832,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of Subscription items.</returns>
-        public virtual IPagedEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptionsPageStream(
+        public virtual IPagedEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptions(
             string project,
             string pageToken = null,
             int? pageSize = null,
@@ -1417,7 +1417,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>An asynchronous sequence of pages of Subscription items.</returns>
-        public override IPagedAsyncEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptionsPageStreamAsync(
+        public override IPagedAsyncEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptionsAsync(
             string project,
             string pageToken = null,
             int? pageSize = null,
@@ -1442,7 +1442,7 @@ namespace Google.Pubsub.V1
         /// A value of <c>null</c> or 0 uses a server-defined page size.</param>
         /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
         /// <returns>A sequence of pages of Subscription items.</returns>
-        public override IPagedEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptionsPageStream(
+        public override IPagedEnumerable<ListSubscriptionsResponse, Subscription> ListSubscriptions(
             string project,
             string pageToken = null,
             int? pageSize = null,

--- a/src/Google.Pubsub.V1/project.json
+++ b/src/Google.Pubsub.V1/project.json
@@ -14,7 +14,7 @@
   },
 
   "dependencies": {
-    "Google.Api.Gax": "0.1.0-CI00051",
+    "Google.Api.Gax": "0.1.0-CI00055",
     "Google.Apis.Auth": "1.13.0",
     "Google.Protobuf": "3.0.0-beta3",
     "Grpc.Auth": "0.14.0",


### PR DESCRIPTION
I've also renamed all the methods to remove the PageStream suffix;
this was slightly tricky in the Datastore case where we've got a manually-written page-streaming 
operation, with more complications due to an alternative taking a GqlQuery which can't be
page-streamed. That can all be tweaked though...