### PR TITLE
Use a custom class for Datastore query results.

### DIFF
--- a/src/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
@@ -63,37 +63,14 @@ namespace Google.Datastore.V1Beta3
 
         /// <inheritdoc/>
         public override KeyFactory CreateKeyFactory(string kind) => new KeyFactory(_partitionId, kind);
-
+        
         /// <inheritdoc/>
-        public override RunQueryResponse RunQuerySingleCall(
-            Query query, 
-            ReadConsistency? readConsistency = null,
-            CallSettings callSettings = null) =>
-            Client.RunQuery(ProjectId, _partitionId, GetReadOptions(readConsistency), query, callSettings);
-
-        /// <inheritdoc/>
-        public override Task<RunQueryResponse> RunQuerySingleCallAsync(
-            Query query,
-            ReadConsistency? readConsistency = null,
-            CallSettings callSettings = null) =>
-            Client.RunQueryAsync(ProjectId, _partitionId, GetReadOptions(readConsistency), query, callSettings);
-
-        /// <inheritdoc/>
-        public override RunQueryResponse RunQuerySingleCall(
-            GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null) =>
-            Client.RunQuery(ProjectId, _partitionId, GetReadOptions(readConsistency), query, callSettings);
-
-        /// <inheritdoc/>
-        public override Task<RunQueryResponse> RunQuerySingleCallAsync(
-            GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null) =>
-            Client.RunQueryAsync(ProjectId, _partitionId, GetReadOptions(readConsistency), query, callSettings);
-
-        /// <inheritdoc/>
-        public override IPagedEnumerable<RunQueryResponse, Entity> RunQuery(
+        public override DatastoreQueryResults RunQuery(
             Query query,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)
         {
+            GaxPreconditions.CheckNotNull(query, nameof(query));
             var request = new RunQueryRequest
             {
                 ProjectId = ProjectId,
@@ -101,15 +78,17 @@ namespace Google.Datastore.V1Beta3
                 Query = query,
                 ReadOptions = GetReadOptions(readConsistency)
             };
-            return new PagedEnumerable<RunQueryRequest, RunQueryResponse, Entity>(Client.RunQueryApiCall, request, callSettings);
+            var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
+            return new DatastoreQueryResults(streamer.Sync());
         }
 
         /// <inheritdoc/>
-        public override IPagedAsyncEnumerable<RunQueryResponse, Entity> RunQueryAsync(
+        public override DatastoreAsyncQueryResults RunQueryAsync(
             Query query,
             ReadConsistency? readConsistency = null,
             CallSettings callSettings = null)
         {
+            GaxPreconditions.CheckNotNull(query, nameof(query));
             var request = new RunQueryRequest
             {
                 ProjectId = ProjectId,
@@ -117,7 +96,44 @@ namespace Google.Datastore.V1Beta3
                 Query = query,
                 ReadOptions = GetReadOptions(readConsistency)
             };
-            return new PagedAsyncEnumerable<RunQueryRequest, RunQueryResponse, Entity>(Client.RunQueryApiCall, request, callSettings);
+            var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
+            return new DatastoreAsyncQueryResults(streamer.Async());
+        }
+
+        /// <inheritdoc/>
+        public override DatastoreQueryResults RunQuery(
+            GqlQuery gqlQuery,
+            ReadConsistency? readConsistency = null,
+            CallSettings callSettings = null)
+        {
+            GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
+            var request = new RunQueryRequest
+            {
+                ProjectId = ProjectId,
+                PartitionId = _partitionId,
+                GqlQuery = gqlQuery,
+                ReadOptions = GetReadOptions(readConsistency)
+            };
+            var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
+            return new DatastoreQueryResults(streamer.Sync());
+        }
+
+        /// <inheritdoc/>
+        public override DatastoreAsyncQueryResults RunQueryAsync(
+            GqlQuery gqlQuery,
+            ReadConsistency? readConsistency = null,
+            CallSettings callSettings = null)
+        {
+            GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
+            var request = new RunQueryRequest
+            {
+                ProjectId = ProjectId,
+                PartitionId = _partitionId,
+                GqlQuery = gqlQuery,
+                ReadOptions = GetReadOptions(readConsistency)
+            };
+            var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
+            return new DatastoreAsyncQueryResults(streamer.Async());
         }
 
         /// <inheritdoc/>

--- a/src/Google.Datastore.V1Beta3/DatastoreQueryAsyncResults.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreQueryAsyncResults.cs
@@ -1,0 +1,93 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Datastore.V1Beta3
+{
+    /// <summary>
+    /// An asynchronous Datastore query which is executed lazily and which be viewed in multiple ways.
+    /// </summary>
+    public sealed class DatastoreAsyncQueryResults : IAsyncEnumerable<Entity>
+    {
+        private readonly IAsyncEnumerable<RunQueryResponse> _responses;
+
+        /// <summary>
+        /// Constructs a new instance from the given sequence of responses. This constructor
+        /// is only present to facilitate testing; application code will normally obtain instances
+        /// of this class by calling <see cref="DatastoreDb.RunQuery"/>.
+        /// </summary>
+        /// <remarks>
+        /// The sequence of responses will be returned directly from <see cref="AsResponses"/>, and
+        /// used to lazily construct the other sequences returned by this class. It should not
+        /// contain any null references.
+        /// </remarks>
+        /// <param name="responses">The responses to return.</param>
+        public DatastoreAsyncQueryResults(IAsyncEnumerable<RunQueryResponse> responses)
+        {
+            _responses = GaxPreconditions.CheckNotNull(responses, nameof(responses));
+        }
+
+        /// <inheritdoc />
+        public IAsyncEnumerator<Entity> GetEnumerator() => AsEntities().GetEnumerator();
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="Entity"/> values.
+        /// </summary>
+        /// <remarks>
+        /// This method only exists for symmetry with the other "As*" methods, to make the fact that
+        /// the class implements IEnumerable{Entity} more incidental.
+        /// </remarks>
+        private IAsyncEnumerable<Entity> AsEntities() => AsEntityResults().Select(er => er.Entity);
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="EntityResult"/> values.
+        /// The final result from each batch is modified to use the batch's end cursor instead of
+        /// the original <see cref="EntityResult.Cursor"/> value.
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        /// <returns>A sequence of <see cref="EntityResult"/> values.</returns>
+        public IAsyncEnumerable<EntityResult> AsEntityResults() =>
+            AsBatches().SelectMany(batch =>
+            {
+                var lastResult = batch.EntityResults.LastOrDefault();
+                if (lastResult != null)
+                {
+                    lastResult.Cursor = batch.EndCursor;
+                }
+                return batch.EntityResults.ToAsyncEnumerable();
+            });
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="RunQueryResponse"/> values
+        /// exactly as returned by the Datastore API. This method is only useful if the application
+        /// wishes to examine the <see cref="RunQueryResponse.Query"/> property; otherwise, use
+        /// <see cref="AsBatches"/> to obtain the sequence of batches.
+        /// </summary>
+        /// <returns>A sequence of <see cref="RunQueryResponse"/> values.</returns>
+        public IAsyncEnumerable<RunQueryResponse> AsResponses() => _responses;
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="QueryResultBatch"/> values.
+        /// This method is only useful if the application wishes to process a batch at a time; if the
+        /// details of how the API splits the results into batches is not needed, use <see cref="AsEntityResults"/>
+        /// or simply iterate over the entities.
+        /// </summary>
+        /// <returns>A sequence of <see cref="QueryResultBatch"/> values.</returns>
+        public IAsyncEnumerable<QueryResultBatch> AsBatches() => _responses.Select(r => r.Batch);
+    }
+}

--- a/src/Google.Datastore.V1Beta3/DatastoreQueryResults.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreQueryResults.cs
@@ -1,0 +1,97 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Datastore.V1Beta3
+{
+    /// <summary>
+    /// A Datastore query which is executed lazily and which be viewed in multiple ways.
+    /// </summary>
+    public sealed class DatastoreQueryResults : IEnumerable<Entity>
+    {
+        private readonly IEnumerable<RunQueryResponse> _responses;
+
+        /// <summary>
+        /// Constructs a new instance from the given sequence of responses. This constructor
+        /// is only present to facilitate testing; application code will normally obtain instances
+        /// of this class by calling <see cref="DatastoreDb.RunQuery"/>.
+        /// </summary>
+        /// <remarks>
+        /// The sequence of responses will be returned directly from <see cref="AsResponses"/>, and
+        /// used to lazily construct the other sequences returned by this class. It should not
+        /// contain any null references.
+        /// </remarks>
+        /// <param name="responses">The responses to return.</param>
+        public DatastoreQueryResults(IEnumerable<RunQueryResponse> responses)
+        {
+            _responses = GaxPreconditions.CheckNotNull(responses, nameof(responses));
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<Entity> GetEnumerator() => AsEntities().GetEnumerator();
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="Entity"/> values.
+        /// </summary>
+        /// <remarks>
+        /// This method only exists for symmetry with the other "As*" methods, to make the fact that
+        /// the class implements IEnumerable{Entity} more incidental.
+        /// </remarks>
+        private IEnumerable<Entity> AsEntities() => AsEntityResults().Select(er => er.Entity);
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="EntityResult"/> values.
+        /// The final result from each batch is modified to use the batch's end cursor instead of
+        /// the original <see cref="EntityResult.Cursor"/> value.
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        /// <returns>A sequence of <see cref="EntityResult"/> values.</returns>
+        public IEnumerable<EntityResult> AsEntityResults() =>
+            AsBatches().SelectMany(batch =>
+            {
+                var lastResult = batch.EntityResults.LastOrDefault();
+                if (lastResult != null)
+                {
+                    lastResult.Cursor = batch.EndCursor;
+                }
+                return batch.EntityResults;
+            });
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="RunQueryResponse"/> values
+        /// exactly as returned by the Datastore API. This method is only useful if the application
+        /// wishes to examine the <see cref="RunQueryResponse.Query"/> property; otherwise, use
+        /// <see cref="AsBatches"/> to obtain the sequence of batches.
+        /// </summary>
+        /// <returns>A sequence of <see cref="RunQueryResponse"/> values.</returns>
+        public IEnumerable<RunQueryResponse> AsResponses() => _responses;
+
+        /// <summary>
+        /// Returns the results of this query as a sequence of <see cref="QueryResultBatch"/> values.
+        /// This method is only useful if the application wishes to process a batch at a time; if the
+        /// details of how the API splits the results into batches is not needed, use <see cref="AsEntityResults"/>
+        /// or simply iterate over the entities.
+        /// </summary>
+        /// <returns>A sequence of <see cref="QueryResultBatch"/> values.</returns>
+        public IEnumerable<QueryResultBatch> AsBatches() => _responses.Select(r => r.Batch);
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/Google.Datastore.V1Beta3/Properties/AssemblyInfo.cs
+++ b/src/Google.Datastore.V1Beta3/Properties/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Google.Datastore.V1Beta3.Tests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100afab79952ee22215f12b4e09337e65509c943fbc22d7006bc371d581d0f0ebf0da5d8039aab2607fb68a138a5d80a71bc02b7ebf586dbe1f2493c0ab20423ababfd15ce74d2264a6b37745f3658f016abaad662182aaef634a60f1346fcc45343acab5b6781535a3134818e13fac895a6c106c0480e34bbb06cb123e5583d8d2")]

--- a/src/Google.Datastore.V1Beta3/QueryStreamer.cs
+++ b/src/Google.Datastore.V1Beta3/QueryStreamer.cs
@@ -1,0 +1,126 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using static Google.Datastore.V1Beta3.QueryResultBatch.Types;
+
+namespace Google.Datastore.V1Beta3
+{
+    /// <summary>
+    /// Creates a stream of responses (synchronous and asynchronous) from a query.
+    /// </summary>
+    internal class QueryStreamer
+    {
+        private readonly RunQueryRequest _initialRequest;
+        private readonly ApiCall<RunQueryRequest, RunQueryResponse> _apiCall;
+        private readonly CallSettings _callSettings;
+
+        internal QueryStreamer(RunQueryRequest initialRequest, ApiCall<RunQueryRequest, RunQueryResponse> apiCall, CallSettings callSettings)
+        {
+            _initialRequest = GaxPreconditions.CheckNotNull(initialRequest, nameof(initialRequest)).Clone();
+            _apiCall = GaxPreconditions.CheckNotNull(apiCall, nameof(apiCall));
+            _callSettings = callSettings;
+        }
+
+        // The real business logic of this class is all in the following two methods. The rest is pretty much boilerplate.
+
+        private static void ModifyRequest(RunQueryRequest request, RunQueryResponse response)
+        {
+            // Transition from GQL to structured queries.
+            if (response.Query != null)
+            {
+                request.Query = response.Query;
+            }
+            // Offset/limit/cursor handling.
+            var query = request.Query;
+            var batch = response.Batch;
+            query.Offset -= batch.SkippedResults;
+            if (query.Limit > 0)
+            {
+                query.Limit -= batch.EntityResults.Count;
+            }
+            query.StartCursor = batch.EndCursor;
+        }
+
+        private static bool MoreResultsAvailable(RunQueryResponse response) =>
+            response.Batch.MoreResults == MoreResultsType.NotFinished;
+
+        internal IAsyncEnumerable<RunQueryResponse> Async() => new AsyncQueryEnumerable(this);
+
+        internal IEnumerable<RunQueryResponse> Sync()
+        {
+            var request = _initialRequest.Clone();
+            RunQueryResponse response;
+            do
+            {
+                response = _apiCall.Sync(request, _callSettings);
+                yield return response;
+                ModifyRequest(request, response);
+            } while (MoreResultsAvailable(response));
+        }
+
+        private class AsyncQueryEnumerable : IAsyncEnumerable<RunQueryResponse>
+        {
+            private readonly QueryStreamer _parent;
+
+            internal AsyncQueryEnumerable(QueryStreamer parent)
+            {
+                _parent = parent;
+            }
+
+            public IAsyncEnumerator<RunQueryResponse> GetEnumerator()
+                => new AsyncQueryEnumerator(_parent);
+
+            private class AsyncQueryEnumerator : IAsyncEnumerator<RunQueryResponse>
+            {
+                private readonly QueryStreamer _parent;
+                private RunQueryRequest _request;
+                private bool _finished;
+
+                public AsyncQueryEnumerator(QueryStreamer _parent)
+                {
+                    this._parent = _parent;
+                    _request = _parent._initialRequest.Clone();
+                }
+
+                public RunQueryResponse Current { get; private set; }
+
+                public async Task<bool> MoveNext(CancellationToken cancellationToken)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (_finished)
+                    {
+                        return false;
+                    }
+                    CallSettings effectiveCallSettings = _parent._callSettings;
+                    if (cancellationToken != default(CancellationToken))
+                    {
+                        effectiveCallSettings = effectiveCallSettings?.Clone() ?? new CallSettings();
+                        effectiveCallSettings.CancellationToken = cancellationToken;
+                    }
+                    var response = await _parent._apiCall.Async(_request, effectiveCallSettings);
+                    _finished = !MoreResultsAvailable(response);
+                    ModifyRequest(_request, response);
+                    Current = response;
+                    return true;
+                }
+
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/test/Google.Datastore.V1Beta3.Tests/DatastoreAsyncQueryResultsTest.cs
+++ b/test/Google.Datastore.V1Beta3.Tests/DatastoreAsyncQueryResultsTest.cs
@@ -1,0 +1,112 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Protobuf;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Datastore.V1Beta3.QueryResultBatch.Types;
+
+namespace Google.Datastore.V1Beta3.Tests
+{
+    public class DatastoreAsyncQueryResultsTest
+    {
+        private static readonly Entity[] _entities = Enumerable
+            .Range(0, 20)
+            .Select(index => new Entity { ["id"] = index }).ToArray();
+        private static readonly EntityResult[] _entityResults = _entities
+            .Select(e => new EntityResult { Entity = e, Cursor = ByteString.CopyFromUtf8($"entity-{(int)e["id"]}") })
+            .ToArray();
+
+        private static readonly RunQueryResponse[] _responses = new[]
+        {
+            // Response just skipping first 10 results
+            new RunQueryResponse
+            {
+                Batch = new QueryResultBatch
+                {
+                    SkippedCursor = ByteString.CopyFromUtf8("skipped10"),
+                    SkippedResults = 10,
+                    EndCursor = ByteString.CopyFromUtf8("after-batch-1"),
+                    MoreResults = MoreResultsType.NotFinished
+                }
+            },
+            // Response skipping 5 results, then returning 5 results
+            new RunQueryResponse
+            {
+                Batch = new QueryResultBatch
+                {
+                    SkippedCursor = ByteString.CopyFromUtf8("skipped5"),
+                    SkippedResults = 5,
+                    EndCursor = ByteString.CopyFromUtf8("after-batch-2"),
+                    MoreResults = MoreResultsType.NotFinished,
+                    EntityResults = { { _entityResults.Take(5) } }
+                }
+            },
+            // Response with 10 results, and more to come.
+            new RunQueryResponse
+            {
+                Batch = new QueryResultBatch
+                {
+                    EndCursor = ByteString.CopyFromUtf8("after-batch-3"),
+                    MoreResults = MoreResultsType.NotFinished,
+                    EntityResults = { { _entityResults.Skip(5).Take(10) } }
+                }
+            },
+            // Response with final 5 results.
+            new RunQueryResponse
+            {
+                Batch = new QueryResultBatch
+                {
+                    EndCursor = ByteString.CopyFromUtf8("after-batch-4"),
+                    MoreResults = MoreResultsType.MoreResultsAfterLimit,
+                    EntityResults = { { _entityResults.Skip(15) } }
+                }
+            }
+        };
+
+        [Fact]
+        public async Task AsEntities()
+        {
+            var results = new DatastoreAsyncQueryResults(_responses.Select(r => r.Clone()).ToAsyncEnumerable());
+            Assert.Equal(_entities, await results.ToList());
+        }
+
+        [Fact]
+        public async Task AsEntityResults()
+        {
+            var results = new DatastoreAsyncQueryResults(_responses.Select(r => r.Clone()).ToAsyncEnumerable());
+            var expected = _entityResults.ToList();
+            expected[4].Cursor = _responses[1].Batch.EndCursor;
+            expected[14].Cursor = _responses[2].Batch.EndCursor;
+            expected[19].Cursor = _responses[3].Batch.EndCursor;
+            Assert.Equal(expected, await results.AsEntityResults().ToList());
+        }
+
+        [Fact]
+        public async Task AsBatches()
+        {
+            var results = new DatastoreAsyncQueryResults(_responses.Select(r => r.Clone()).ToAsyncEnumerable());
+            var expected = new[] { _responses[0].Batch, _responses[1].Batch, _responses[2].Batch, _responses[3].Batch };
+            Assert.Equal(expected, await results.AsBatches().ToList());
+        }
+
+        [Fact]
+        public async Task AsResponses()
+        {
+            var results = new DatastoreAsyncQueryResults(_responses.Select(r => r.Clone()).ToAsyncEnumerable());
+            Assert.Equal(_responses, await results.AsResponses().ToList());
+        }
+    }
+}

--- a/test/Google.Datastore.V1Beta3.Tests/DatastoreQueryResultsTest.cs
+++ b/test/Google.Datastore.V1Beta3.Tests/DatastoreQueryResultsTest.cs
@@ -1,0 +1,111 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Protobuf;
+using System.Linq;
+using Xunit;
+using static Google.Datastore.V1Beta3.QueryResultBatch.Types;
+
+namespace Google.Datastore.V1Beta3.Tests
+{
+    public class DatastoreQueryResultsTest
+    {
+        private static readonly Entity[] _entities = Enumerable
+            .Range(0, 20)
+            .Select(index => new Entity { ["id"] = index }).ToArray();
+        private static readonly EntityResult[] _entityResults = _entities
+            .Select(e => new EntityResult { Entity = e, Cursor = ByteString.CopyFromUtf8($"entity-{(int)e["id"]}") })
+            .ToArray();
+
+        private static readonly RunQueryResponse[] _responses = new[]
+        {
+            // Response just skipping first 10 results
+            new RunQueryResponse
+            {
+                Batch = new QueryResultBatch
+                {
+                    SkippedCursor = ByteString.CopyFromUtf8("skipped10"),
+                    SkippedResults = 10,
+                    EndCursor = ByteString.CopyFromUtf8("after-batch-1"),
+                    MoreResults = MoreResultsType.NotFinished
+                }
+            },
+            // Response skipping 5 results, then returning 5 results
+            new RunQueryResponse
+            {
+                Batch = new QueryResultBatch
+                {
+                    SkippedCursor = ByteString.CopyFromUtf8("skipped5"),
+                    SkippedResults = 5,
+                    EndCursor = ByteString.CopyFromUtf8("after-batch-2"),
+                    MoreResults = MoreResultsType.NotFinished,
+                    EntityResults = { { _entityResults.Take(5) } }
+                }
+            },
+            // Response with 10 results, and more to come.
+            new RunQueryResponse
+            {
+                Batch = new QueryResultBatch
+                {
+                    EndCursor = ByteString.CopyFromUtf8("after-batch-3"),
+                    MoreResults = MoreResultsType.NotFinished,
+                    EntityResults = { { _entityResults.Skip(5).Take(10) } }
+                }
+            },
+            // Response with final 5 results.
+            new RunQueryResponse
+            {
+                Batch = new QueryResultBatch
+                {
+                    EndCursor = ByteString.CopyFromUtf8("after-batch-4"),
+                    MoreResults = MoreResultsType.MoreResultsAfterLimit,
+                    EntityResults = { { _entityResults.Skip(15) } }
+                }
+            }
+        };
+
+        [Fact]
+        public void AsEntities()
+        {
+            var results = new DatastoreQueryResults(_responses.Select(r => r.Clone()));
+            Assert.Equal(_entities, results);
+        }
+
+        [Fact]
+        public void AsEntityResults()
+        {
+            var results = new DatastoreQueryResults(_responses.Select(r => r.Clone()));
+            var expected = _entityResults.ToList();
+            expected[4].Cursor = _responses[1].Batch.EndCursor;
+            expected[14].Cursor = _responses[2].Batch.EndCursor;
+            expected[19].Cursor = _responses[3].Batch.EndCursor;
+            Assert.Equal(expected, results.AsEntityResults());
+        }
+
+        [Fact]
+        public void AsBatches()
+        {
+            var results = new DatastoreQueryResults(_responses.Select(r => r.Clone()));
+            var expected = new[] { _responses[0].Batch, _responses[1].Batch, _responses[2].Batch, _responses[3].Batch };
+            Assert.Equal(expected, results.AsBatches());
+        }
+
+        [Fact]
+        public void AsResponses()
+        {
+            var results = new DatastoreQueryResults(_responses.Select(r => r.Clone()));
+            Assert.Equal(_responses, results.AsResponses());
+        }
+    }
+}

--- a/test/Google.Datastore.V1Beta3.Tests/QueryStreamerTest.cs
+++ b/test/Google.Datastore.V1Beta3.Tests/QueryStreamerTest.cs
@@ -1,0 +1,175 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Protobuf;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using static Google.Datastore.V1Beta3.QueryResultBatch.Types;
+
+namespace Google.Datastore.V1Beta3.Tests
+{
+    public class QueryStreamerTest
+    {
+        [Fact]
+        public void GqlQueryIsTransformed()
+        {
+            var structured = new Query
+            {
+                Limit = 10,
+                Projection = { "foo", "bar" }
+            };
+            // No, this isn't real GQL. But it's an easy way of testing things.
+            var gql = new GqlQuery { QueryString = structured.ToString() };
+            var server = new FakeServer(4);
+            var streamer = new QueryStreamer(new RunQueryRequest { GqlQuery = gql }, server.CreateApiCall(), null);
+            AssertEntities(streamer, 0, 10);
+            var firstStructured = new Query(structured) { Limit = 6, StartCursor = ByteString.CopyFromUtf8("4") };
+            Assert.Equal(firstStructured, server.Requests[1].Query);
+        }
+        
+        [Fact]
+        public void LimitAndOffset()
+        {
+            var query = new Query
+            {
+                Limit = 7,
+                Offset = 5
+            };
+            var server = new FakeServer(4);
+            var streamer = new QueryStreamer(new RunQueryRequest { Query = query }, server.CreateApiCall(), null);
+            AssertEntities(streamer, 5, 7);
+            AssertLimits(server, 7, 7, 4);
+            AssertOffsets(server, 5, 1, 0);
+        }
+
+        [Fact]
+        public void NoLimit()
+        {
+            var query = new Query { Offset = 5 };
+            var server = new FakeServer(11);
+            var streamer = new QueryStreamer(new RunQueryRequest { Query = query }, server.CreateApiCall(), null);
+            AssertEntities(streamer, 5, 15);
+            AssertLimits(server, null, null);
+            AssertOffsets(server, 5, 0);
+        }
+
+        private void AssertLimits(FakeServer server, params int?[] expectedLimits)
+        {
+            Assert.Equal(expectedLimits, server.Requests.Select(r => r.Query?.Limit));
+        }
+
+        private void AssertOffsets(FakeServer server, params int[] expectedOffsets)
+        {
+            Assert.Equal(expectedOffsets, server.Requests.Select(r => r.Query.Offset));
+        }
+
+        private void AssertEntities(QueryStreamer streamer, int offset, int limit)
+        {
+            var entities = streamer.Sync().SelectMany(response => response.Batch.EntityResults).Select(er => er.Entity).ToList();
+            Assert.Equal(FakeServer.Entities.Skip(offset).Take(limit), entities);
+        }
+
+        private class FakeServer
+        {
+
+            internal static List<Entity> Entities { get; } = Enumerable
+                .Range(0, 20)
+                .Select(index => new Entity { ["id"] = index }).ToList();
+            private static List<EntityResult> EntityResults { get; } = Entities
+                .Select((value, index) => new EntityResult {
+                    Entity = value,
+                    // The +1 is because we want the position *after* the entity.
+                    Cursor = ByteString.CopyFromUtf8((index + 1).ToString()) })
+                .ToList();
+
+            private readonly int _resultsToProcessPerCall;
+            internal List<RunQueryRequest> Requests { get; } = new List<RunQueryRequest>();
+
+            /// <summary>
+            /// Creates a server that "processes" (skips or returns) a given number of results per call
+            /// before returning the response.
+            /// </summary>
+            internal FakeServer(int resultsToProcessPerCall)
+            {
+                _resultsToProcessPerCall = resultsToProcessPerCall;
+            }
+
+            internal ApiCall<RunQueryRequest, RunQueryResponse> CreateApiCall()
+            {
+                return new ClientHelper(DatastoreSettings.GetDefault()).BuildApiCall<RunQueryRequest, RunQueryResponse>(RunQueryAsync, RunQuery, null);
+            }
+
+            private RunQueryResponse RunQuery(RunQueryRequest request, CallOptions options)
+            {
+                Requests.Add(request.Clone());
+                var response = new RunQueryResponse { Batch = new QueryResultBatch() };
+                if (request.GqlQuery != null)
+                {
+                    response.Query = Query.Parser.ParseJson(request.GqlQuery.QueryString);
+                    request.Query = response.Query;
+                }
+                var query = request.Query;
+                var batch = response.Batch;
+                batch.MoreResults = MoreResultsType.NotFinished;
+                int leftToSkip = query.Offset;
+                int position = query.StartCursor.IsEmpty ? 0 : int.Parse(query.StartCursor.ToStringUtf8());
+                for (int i = 0; i < _resultsToProcessPerCall; i++)
+                {
+                    if (position >= EntityResults.Count)
+                    {
+                        batch.MoreResults = MoreResultsType.NoMoreResults;
+                        break;
+                    }
+                    if (EntityResults[position].Cursor == query.EndCursor)
+                    {
+                        batch.MoreResults = MoreResultsType.MoreResultsAfterCursor;
+                        break;
+                    }
+                    if (batch.EntityResults.Count == query.Limit)
+                    {
+                        // Status will be set after the loop.
+                        break;
+                    }
+                    if (leftToSkip > 0)
+                    {
+                        leftToSkip--;
+                        batch.SkippedResults++;
+                        batch.SkippedCursor = EntityResults[position].Cursor;
+                    }
+                    else
+                    {
+                        batch.EntityResults.Add(EntityResults[position]);
+                    }
+                    position++;
+                }
+                batch.EndCursor = batch.EntityResults.LastOrDefault()?.Cursor ?? batch.SkippedCursor;
+                // Mustn't do this just in the loop, as we might ask for exactly the number processed.
+                if (batch.EntityResults.Count == query.Limit)
+                {
+                    batch.MoreResults = MoreResultsType.MoreResultsAfterLimit;
+                }
+                return response;
+            }
+
+            private AsyncUnaryCall<RunQueryResponse> RunQueryAsync(RunQueryRequest request, CallOptions options)
+            {
+                throw new NotImplementedException("Faking async calls is currently awkward.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows the results to be transparently streamed as:

- Entities (the default)
- EntityResults (with the final cursor being replaced by the batch
cursor)
- Batches
- Responses

I'm not terribly keen on the naming at the moment, as `RunQuery` doesn't actually run the query - it's all lazy. But I think anything else ends up being more confusing.

Other platforms expose an iterator rather than an iterable object, but exposing the lazy iterable is more idiomatic in .NET - it's common in LINQ etc.
