### PR TITLE
Updates to the transaction API, and a few tidy-ups

### DIFF
--- a/src/Google.Datastore.V1Beta3/DatastoreDb.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreDb.cs
@@ -70,7 +70,6 @@ namespace Google.Datastore.V1Beta3
         /// </summary>
         public virtual string NamespaceId { get { throw new NotImplementedException(); } }
 
-
         /// <summary>
         /// Creates a <see cref="DatastoreDb"/> to operate on the partition identified by <paramref name="projectId"/>
         /// and <paramref name="namespaceId"/>, using the <paramref name="client"/> to perform remote operations.
@@ -94,44 +93,6 @@ namespace Google.Datastore.V1Beta3
         }
 
         /// <summary>
-        /// Executes the given GQL query, returning a result set that can be viewed as a sequence of
-        /// entities, entity results (with cursors), batches, or raw API responses.
-        /// </summary>
-        /// <remarks>
-        /// The results are requested lazily: no API calls will be made until the application starts
-        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
-        /// multiple times will execute the query again, potentially returning different results.
-        /// </remarks>
-        /// <param name="query">The query to execute. Must not be null.</param>
-        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
-        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
-        public virtual DatastoreQueryResults RunQuery(
-            Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// Executes the given GQL query, returning a result set that can be viewed as an asynchronous
-        /// sequence of entities, entity results (with cursors), batches, or raw API responses.
-        /// </summary>
-        /// <remarks>
-        /// The results are requested lazily: no API calls will be made until the application starts
-        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
-        /// multiple times will execute the query again, potentially returning different results.
-        /// </remarks>
-        /// <param name="query">The query to execute. Must not be null.</param>
-        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
-        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
-        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
-        public virtual DatastoreAsyncQueryResults RunQueryAsync(
-            GqlQuery gqlQuery, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
         /// Executes the given structured query, returning a result set that can be viewed as a sequence of
         /// entities, entity results (with cursors), batches, or raw API responses.
         /// </summary>
@@ -145,7 +106,7 @@ namespace Google.Datastore.V1Beta3
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
         public virtual DatastoreQueryResults RunQuery(
-            GqlQuery gqlQuery, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+            Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -165,6 +126,44 @@ namespace Google.Datastore.V1Beta3
         /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
         public virtual DatastoreAsyncQueryResults RunQueryAsync(
             Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+        
+        /// <summary>
+        /// Executes the given GQL query, returning a result set that can be viewed as a sequence of
+        /// entities, entity results (with cursors), batches, or raw API responses.
+        /// </summary>
+        /// <remarks>
+        /// The results are requested lazily: no API calls will be made until the application starts
+        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// multiple times will execute the query again, potentially returning different results.
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
+        public virtual DatastoreQueryResults RunQuery(
+            GqlQuery gqlQuery, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Executes the given GQL query, returning a result set that can be viewed as an asynchronous
+        /// sequence of entities, entity results (with cursors), batches, or raw API responses.
+        /// </summary>
+        /// <remarks>
+        /// The results are requested lazily: no API calls will be made until the application starts
+        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// multiple times will execute the query again, potentially returning different results.
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
+        public virtual DatastoreAsyncQueryResults RunQueryAsync(
+            GqlQuery gqlQuery, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -279,10 +278,10 @@ namespace Google.Datastore.V1Beta3
         /// This call may perform multiple RPC operations in order to look up all keys.
         /// </para>
         /// <para>
-        /// This overload does not support the <see cref="ReadConsistency"/> or <see cref="CallSettings "/>to be specified due to restrictions with
+        /// This overload does not support the <see cref="ReadConsistency"/> or <see cref="CallSettings "/> to be specified due to restrictions with
         /// methods containing a parameter array and optional parameters.
         /// It simply delegates to <see cref="Lookup(IEnumerable{Key}, ReadConsistency?, CallSettings)"/>, passing in a <c>null</c>
-        /// value for the read consistency and all settings.
+        /// value for the read consistency and call settings.
         /// </para>
         /// </remarks>
         /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
@@ -328,10 +327,10 @@ namespace Google.Datastore.V1Beta3
         /// This call may perform multiple RPC operations in order to look up all keys.
         /// </para>
         /// <para>
-        /// This overload does not support the <see cref="ReadConsistency"/> or <see cref="CallSettings "/>to be specified due to restrictions with
+        /// This overload does not support the <see cref="ReadConsistency"/> or <see cref="CallSettings "/> to be specified due to restrictions with
         /// methods containing a parameter array and optional parameters.
         /// It simply delegates to <see cref="LookupAsync(IEnumerable{Key}, ReadConsistency?, CallSettings)"/>, passing in a <c>null</c>
-        /// value for the read consistency and all settings.
+        /// value for the read consistency and call settings.
         /// </para>
         /// </remarks>
         /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>

--- a/src/Google.Datastore.V1Beta3/DatastoreTransaction.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreTransaction.cs
@@ -16,24 +16,38 @@ using Google.Protobuf;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using static Google.Datastore.V1Beta3.CommitRequest.Types;
 
 namespace Google.Datastore.V1Beta3
 {
-    // TODO: Async
-    // TODO: Take CallSettings on each call?
     // TODO: Determine handling of multiple calls (e.g. Insert + Update + Delete) for same entity
     // TODO: Validate that entities to be updated/deleted have keys.
     // TODO: Document cloning policy.
     // TODO: Change return type of Commit to something simpler?
-    // TODO: Make Get return something which can be indexed by Key
+    // TODO: Make Lookup return something which can be indexed by Key
+    // TODO: Give the transaction itself a partition ID rather than just a project ID?
 
     /// <summary>
-    /// Convenience wrapper around a Datastore transaction.
+    /// <para>
+    /// Convenience wrapper around a Datastore transaction. All mutation operations (<see cref="Insert(IEnumerable{Entity})"/>,
+    /// <see cref="Delete(IEnumerable{Key})"/>, <see cref="Update(IEnumerable{Entity})"/> and <see cref="Upsert(IEnumerable{Entity})"/>)
+    /// merely add to a list of mutations which are performed in a single <see cref="Commit(CallSettings)"/> or <see cref="CommitAsync(CallSettings)"/>
+    /// operation. This means the mutation methods are all synchronous and do not take call settings, as they don't perform any
+    /// API operations.
+    /// </para>
+    /// <para>
+    /// Disposing of a transaction calls <see cref="Rollback(CallSettings)"/> if the transaction has not already been committed
+    /// or rolled back.
+    /// </para>
     /// </summary>
     public sealed class DatastoreTransaction : IDisposable
     {
-        private readonly ByteString _transactionId;
+        /// <summary>
+        /// The ID of the transaction, used implicitly in operations performed with this object.
+        /// </summary>
+        public ByteString TransactionId { get; }
+
         private readonly DatastoreClient _client;
         private readonly string _projectId;
         private readonly List<Mutation> _mutations = new List<Mutation>();
@@ -51,49 +65,239 @@ namespace Google.Datastore.V1Beta3
         {
             _client = GaxPreconditions.CheckNotNull(client, nameof(client));
             _projectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            _transactionId = GaxPreconditions.CheckNotNull(transactionId, nameof(transactionId));
-            _readOptions = new ReadOptions { Transaction = _transactionId };
-            _active = true; 
+            TransactionId = GaxPreconditions.CheckNotNull(transactionId, nameof(transactionId));
+            _readOptions = new ReadOptions { Transaction = TransactionId };
+            _active = true;
         }
 
-        public Entity Lookup(Key key) => DatastoreDb.LookupImpl(_client, _projectId, _readOptions, new[] { key }, null)[0]; 
-        public IReadOnlyList<Entity> Lookup(params Key[] keys) => Lookup((IEnumerable<Key>)keys);
-        public IReadOnlyList<Entity> Lookup(IEnumerable<Key> keys) => DatastoreDb.LookupImpl(_client, _projectId, _readOptions, keys, null);
+        /// <summary>
+        /// Executes the given structured query in this transaction, returning a result set that can be viewed as a sequence of
+        /// entities, entity results (with cursors), batches, or raw API responses.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Using a transaction ensures that a commit operation will fail if any of the entities returned
+        /// by this query have been modified while the transaction is active. Note that modifications performed
+        /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// <para>
+        /// The results are requested lazily: no API calls will be made until the application starts
+        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// multiple times will execute the query again, potentially returning different results.
+        /// </para>
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
+        /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
+        public DatastoreQueryResults RunQuery(Query query, PartitionId partitionId, CallSettings callSettings = null)
+        {
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            var request = new RunQueryRequest
+            {
+                ProjectId = _projectId,
+                PartitionId = partitionId,
+                Query = query,
+                ReadOptions = _readOptions
+            };
+            var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
+            return new DatastoreQueryResults(streamer.Sync());
+        }
+
 
         /// <summary>
-        /// Runs the specified query in this transaction.
+        /// Executes the given structured query in this transaction, returning a result set that can be viewed as an asynchronous
+        /// sequence of entities, entity results (with cursors), batches, or raw API responses.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Using a transaction ensures that a commit operation will fail if any of the entities returned
         /// by this query have been modified while the transaction is active. Note that modifications performed
         /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// <para>
+        /// The results are requested lazily: no API calls will be made until the application starts
+        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// multiple times will execute the query again, potentially returning different results.
+        /// </para>
         /// </remarks>
-        /// <param name="partitionId">The ID of the partition to run the query against. Must not be null.</param>
-        /// <param name="query">The query to run. Must not be null.</param>
-        /// <returns>The result of the query.</returns>
-        public RunQueryResponse RunQuery(PartitionId partitionId, Query query) =>
-            _client.RunQuery(
-                _projectId,
-                GaxPreconditions.CheckNotNull(partitionId, nameof(partitionId)),
-                _readOptions,
-                GaxPreconditions.CheckNotNull(query, nameof(query)));
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
+        /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
+        public DatastoreAsyncQueryResults RunQueryAsync(Query query, PartitionId partitionId, CallSettings callSettings = null)
+        {
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            var request = new RunQueryRequest
+            {
+                ProjectId = _projectId,
+                PartitionId = partitionId,
+                Query = query,
+                ReadOptions = _readOptions
+            };
+            var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
+            return new DatastoreAsyncQueryResults(streamer.Async());
+        }
+
         /// <summary>
-        /// Runs the specified query in this transaction.
+        /// Executes the given GQL query in this transaction, returning a result set that can be viewed as a sequence of
+        /// entities, entity results (with cursors), batches, or raw API responses.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Using a transaction ensures that a commit operation will fail if any of the entities returned
         /// by this query have been modified while the transaction is active. Note that modifications performed
         /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// <para>
+        /// The results are requested lazily: no API calls will be made until the application starts
+        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// multiple times will execute the query again, potentially returning different results.
+        /// </para>
         /// </remarks>
-        /// <param name="partitionId">The ID of the partition to run the query against. Must not be null.</param>
-        /// <param name="query">The query to run. Must not be null.</param>
-        /// <returns>The result of the query.</returns>
-        public RunQueryResponse RunQuery(PartitionId partitionId, GqlQuery query) =>
-            _client.RunQuery(
-                _projectId,
-                GaxPreconditions.CheckNotNull(partitionId, nameof(partitionId)),
-                _readOptions,
-                GaxPreconditions.CheckNotNull(query, nameof(query)));
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
+        /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
+        public DatastoreQueryResults RunQuery(GqlQuery gqlQuery, PartitionId partitionId, CallSettings callSettings = null)
+        {
+            GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
+            var request = new RunQueryRequest
+            {
+                ProjectId = _projectId,
+                PartitionId = partitionId,
+                GqlQuery = gqlQuery,
+                ReadOptions = _readOptions
+            };
+            var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
+            return new DatastoreQueryResults(streamer.Sync());
+        }
+
+        /// <summary>
+        /// Executes the given GQL query in this transaction, returning a result set that can be viewed as an asynchronous
+        /// sequence of entities, entity results (with cursors), batches, or raw API responses.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Using a transaction ensures that a commit operation will fail if any of the entities returned
+        /// by this query have been modified while the transaction is active. Note that modifications performed
+        /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// <para>
+        /// The results are requested lazily: no API calls will be made until the application starts
+        /// iterating over the results. Iterating over the same <see cref="DatastoreQueryResults"/> object
+        /// multiple times will execute the query again, potentially returning different results.
+        /// </para>
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="partitionId">The partition in which to execute the query. May be null, in which case
+        /// the query is executed in the partition associated with the empty namespace in the project used by this transaction.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A <see cref="DatastoreQueryResults"/> representing the result of the query.</returns>
+        public DatastoreAsyncQueryResults RunQueryAsync(GqlQuery gqlQuery, PartitionId partitionId, CallSettings callSettings = null)
+        {
+            GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
+            var request = new RunQueryRequest
+            {
+                ProjectId = _projectId,
+                PartitionId = partitionId,
+                GqlQuery = gqlQuery,
+                ReadOptions = _readOptions
+            };
+            var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
+            return new DatastoreAsyncQueryResults(streamer.Async());
+        }
+
+        /// <summary>
+        /// Looks up a single entity by key.
+        /// </summary>
+        /// <remarks>This method simply delegates to <see cref="Lookup(IEnumerable{Key}, ReadConsistency?, CallSettings)"/>.</remarks>
+        /// <param name="key">The key to look up. Must not be null, and must be complete.</param>
+        /// <param name="readConsistency">The desired read consistency of the lookup, or null to use the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The entity with the specified key, or <c>null</c> if no such entity exists.</returns>
+        public Entity Lookup(Key key, CallSettings callSettings = null) => Lookup(new[] { key }, callSettings)[0];
+
+        /// <summary>
+        /// Looks up a collection of entities by key.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This call may perform multiple RPC operations in order to look up all keys.
+        /// </para>
+        /// <para>
+        /// This overload does not support the <see cref="CallSettings "/> to be specified due to restrictions with
+        /// methods containing a parameter array and optional parameters.
+        /// It simply delegates to <see cref="Lookup(IEnumerable{Key}, CallSettings)"/>, passing in a <c>null</c>
+        /// value for the call settings.
+        /// </para>
+        /// </remarks>
+        /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
+        /// <returns>A collection of entities with the same size as <paramref name="keys"/>, containing corresponding entity
+        /// references, or <c>null</c> where the key was not found.</returns>
+        public IReadOnlyList<Entity> Lookup(params Key[] keys) => Lookup(keys, null);
+
+        /// <summary>
+        /// Looks up a collection of entities by key.
+        /// </summary>
+        /// <remarks>
+        /// This call may perform multiple RPC operations in order to look up all keys.
+        /// </remarks>
+        /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A collection of entities with the same size as <paramref name="keys"/>, containing corresponding entity
+        /// references, or <c>null</c> where the key was not found.</returns>
+        public IReadOnlyList<Entity> Lookup(IEnumerable<Key> keys, CallSettings callSettings = null) =>
+            DatastoreDb.LookupImpl(_client, _projectId, _readOptions, keys, callSettings);
+
+        /// <summary>
+        /// Looks up a single entity by key asynchronously.
+        /// </summary>
+        /// <remarks>This method simply delegates to <see cref="LookupAsync(IEnumerable{Key}, ReadConsistency?, CallSettings)"/>.</remarks>
+        /// <param name="key">The key to look up. Must not be null, and must be complete.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The entity with the specified key, or <c>null</c> if no such entity exists.</returns>
+        public async Task<Entity> LookupAsync(Key key, CallSettings callSettings = null)
+        {
+            var results = await LookupAsync(new[] { key }, callSettings).ConfigureAwait(false);
+            return results[0];
+        }
+
+        /// <summary>
+        /// Looks up a collection of entities by key asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This call may perform multiple RPC operations in order to look up all keys.
+        /// </para>
+        /// <para>
+        /// This overload does not support the <see cref="CallSettings "/> to be specified due to restrictions with
+        /// methods containing a parameter array and optional parameters.
+        /// It simply delegates to <see cref="LookupAsync(IEnumerable{Key}, CallSettings)"/>, passing in a <c>null</c>
+        /// value for the call settings.
+        /// </para>
+        /// </remarks>
+        /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
+        /// <returns>A collection of entities with the same size as <paramref name="keys"/>, containing corresponding entity
+        /// references, or <c>null</c> where the key was not found.</returns>
+        public Task<IReadOnlyList<Entity>> LookupAsync(params Key[] keys) => LookupAsync(keys, null);
+
+        /// <summary>
+        /// Looks up a collection of entities by key asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// This call may perform multiple RPC operations in order to look up all keys.
+        /// </remarks>
+        /// <param name="keys">The keys to look up. Must not be null, and every element must be non-null and refer to a complete key.</param>
+        /// <param name="readConsistency">The desired read consistency of the lookup, or null to use the default.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A collection of entities with the same size as <paramref name="keys"/>, containing corresponding entity
+        /// references, or <c>null</c> where the key was not found.</returns>
+        public Task<IReadOnlyList<Entity>> LookupAsync(IEnumerable<Key> keys, CallSettings callSettings = null) =>
+            DatastoreDb.LookupImplAsync(_client, _projectId, _readOptions, keys, callSettings);        
 
         private void AddMutations<T>(IEnumerable<T> values, Func<T, Mutation> conversion, string paramName)
         {
@@ -161,11 +365,26 @@ namespace Google.Datastore.V1Beta3
         /// </summary>
         /// <exception cref="InvalidOperationException">The transaction has already been committed or rolled back.</exception>
         /// <returns>The response from the commit operation. This can be used to determine server-allocated keys.</returns>
-        public CommitResponse Commit()
+        public CommitResponse Commit(CallSettings callSettings = null)
         {
             // TODO: What if there are no mutations? Just rollback?
             CheckActive();
-            var response = _client.Commit(_projectId, Mode.Transactional, _transactionId, _mutations);
+            var response = _client.Commit(_projectId, Mode.Transactional, TransactionId, _mutations);
+            _active = false;
+            return response;
+        }
+
+        /// <summary>
+        /// Commits all mutations in this transaction asynchronously.
+        /// </summary>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <exception cref="InvalidOperationException">The transaction has already been committed or rolled back.</exception>
+        /// <returns>The response from the commit operation. This can be used to determine server-allocated keys.</returns>
+        public async Task<CommitResponse> CommitAsync(CallSettings callSettings = null)
+        {
+            // TODO: What if there are no mutations? Just rollback?
+            CheckActive();
+            var response = await _client.CommitAsync(_projectId, Mode.Transactional, TransactionId, _mutations, callSettings);
             _active = false;
             return response;
         }
@@ -175,11 +394,27 @@ namespace Google.Datastore.V1Beta3
         /// </summary>
         /// <remarks>This method is rarely useful explicitly; the <see cref="Dispose"/> method rolls back the transaction if it
         /// is still active, so a <c>using</c> statement is normally preferable to this.</remarks>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <exception cref="InvalidOperationException">The transaction has already been committed or rolled back.</exception>
-        public RollbackResponse Rollback()
+        public RollbackResponse Rollback(CallSettings callSettings = null)
         {
             CheckActive();
-            var response = _client.Rollback(_projectId, _transactionId);
+            var response = _client.Rollback(_projectId, TransactionId, callSettings);
+            _active = false;
+            return response;
+        }
+
+        /// <summary>
+        /// Rolls back this transaction asynchronously.
+        /// </summary>
+        /// <remarks>This method is rarely useful explicitly; the <see cref="Dispose"/> method rolls back the transaction if it
+        /// is still active, so a <c>using</c> statement is normally preferable to this.</remarks>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <exception cref="InvalidOperationException">The transaction has already been committed or rolled back.</exception>
+        public async Task<RollbackResponse> RollbackAsync(CallSettings callSettings = null)
+        {
+            CheckActive();
+            var response = await _client.RollbackAsync(_projectId, TransactionId, callSettings);
             _active = false;
             return response;
         }

--- a/test/Google.Datastore.V1Beta3.IntegrationTests/DatastoreDbTest.cs
+++ b/test/Google.Datastore.V1Beta3.IntegrationTests/DatastoreDbTest.cs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Google.Datastore.V1Beta3.IntegrationTests

--- a/test/Google.Datastore.V1Beta3.IntegrationTests/DatastoreTransactionTest.cs
+++ b/test/Google.Datastore.V1Beta3.IntegrationTests/DatastoreTransactionTest.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Google.Datastore.V1Beta3.IntegrationTests
+{
+    [Collection(nameof(DatastoreFixture))]
+    public class DatastoreTransactionTest
+    {
+        private readonly DatastoreFixture _fixture;
+
+        public DatastoreTransactionTest(DatastoreFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        public void Query_NullPartitionId_UsesEmptyNamespace()
+        {
+            // Deliberately in the empty namespace, which won't be cleaned up automatically - hence the db.Delete call later.
+            var db = DatastoreDb.Create(_fixture.ProjectId);
+            var keyFactory = db.CreateKeyFactory("test");
+            var entity = new Entity
+            {
+                Key = keyFactory.CreateIncompleteKey(),
+                ["foo"] = Guid.NewGuid().ToString()
+            };
+            var insertedKey = db.Insert(entity);
+            try
+            {
+                using (var transaction = db.BeginTransaction())
+                {
+                    var query = new Query("test") { Filter = Filter.Equal("foo", entity["foo"]) };
+                    var results = transaction.RunQuery(query, partitionId: null);
+                    Assert.Equal(1, results.Count());
+                }
+            }
+            finally
+            {
+                db.Delete(insertedKey);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The fact that the partition ID is required on DatastoreTransaction.RunQuery is annoying;
we will investigate whether cross-partition transactions are common, and act accordingly.

The changes to DatastoreDb are *actually* just a reordering to be more consistent.