### PR TITLE
Give a DatastoreTransaction a namespace ID as well as a project ID.

### DIFF
--- a/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreClientSnippets.cs
+++ b/snippets/Google.Datastore.V1Beta3.Snippets/DatastoreClientSnippets.cs
@@ -144,7 +144,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             };
 
             ByteString transactionId = client.BeginTransaction(projectId).Transaction;
-            using (DatastoreTransaction transaction = new DatastoreTransaction(client, projectId, transactionId))
+            using (DatastoreTransaction transaction = new DatastoreTransaction(client, projectId, namespaceId, transactionId))
             {
                 transaction.Insert(book1, book2);
                 CommitResponse response = transaction.Commit();
@@ -248,7 +248,7 @@ namespace Google.Datastore.V1Beta3.Snippets
                 ["text"] = "Text of the message"
             };
             ByteString transactionId = client.BeginTransaction(projectId).Transaction;
-            using (DatastoreTransaction transaction = new DatastoreTransaction(client, projectId, transactionId))
+            using (DatastoreTransaction transaction = new DatastoreTransaction(client, projectId, namespaceId, transactionId))
             {
                 transaction.Insert(entity);
                 var commitResponse = transaction.Commit();
@@ -324,12 +324,13 @@ namespace Google.Datastore.V1Beta3.Snippets
         public void UpdateEntity()
         {
             string projectId = _fixture.ProjectId;
+            string namespaceId = _fixture.NamespaceId;
             Key key = _fixture.LearnDatastoreKey;
 
             // Sample: UpdateEntity
             DatastoreClient client = DatastoreClient.Create();
             ByteString transactionId = client.BeginTransaction(projectId).Transaction;
-            using (DatastoreTransaction transaction = new DatastoreTransaction(client, projectId, transactionId))
+            using (DatastoreTransaction transaction = new DatastoreTransaction(client, projectId, namespaceId, transactionId))
             {
                 Entity entity = transaction.Lookup(key);
                 entity["priority"] = 5;
@@ -598,6 +599,7 @@ namespace Google.Datastore.V1Beta3.Snippets
         public void TransactionReadAndWrite()
         {
             string projectId = _fixture.ProjectId;
+            string namespaceId = _fixture.NamespaceId;
             long amount = 1000L;
             Key fromKey = CreateAccount("Jill", 20000L);
             Key toKey = CreateAccount("Beth", 15500L);
@@ -605,7 +607,7 @@ namespace Google.Datastore.V1Beta3.Snippets
             // Sample: TransactionReadAndWrite
             DatastoreClient client = DatastoreClient.Create();
             ByteString transactionId = client.BeginTransaction(projectId).Transaction;
-            using (DatastoreTransaction transaction = new DatastoreTransaction(client, projectId, transactionId))
+            using (DatastoreTransaction transaction = new DatastoreTransaction(client, projectId, namespaceId, transactionId))
             {
                 // The return value from DatastoreTransaction.Get contains the fetched entities
                 // in the same order as they are in the call.

--- a/src/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
+++ b/src/Google.Datastore.V1Beta3/DatastoreDbImpl.cs
@@ -138,13 +138,13 @@ namespace Google.Datastore.V1Beta3
 
         /// <inheritdoc/>
         public override DatastoreTransaction BeginTransaction(CallSettings callSettings = null) =>
-            new DatastoreTransaction(Client, ProjectId, Client.BeginTransaction(ProjectId, callSettings).Transaction);
+            new DatastoreTransaction(Client, ProjectId, NamespaceId, Client.BeginTransaction(ProjectId, callSettings).Transaction);
 
         /// <inheritdoc/>
         public async override Task<DatastoreTransaction> BeginTransactionAsync(CallSettings callSettings = null)
         {
             var response = await Client.BeginTransactionAsync(ProjectId, callSettings).ConfigureAwait(false);
-            return new DatastoreTransaction(Client, ProjectId, response.Transaction);
+            return new DatastoreTransaction(Client, ProjectId, NamespaceId, response.Transaction);
         }                
 
         /// <inheritdoc/>


### PR DESCRIPTION
This is only used for querying, but makes it that much smoother to use from the DatastoreDb world.

Fixes issue #236.