### PR TITLE
Fix doc builds

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ A library for working with [Google Stackdriver Logging](https://cloud.google.com
 
 ## Log4net integration - Google.Logging.Log4Net (alpha)
 
-[GoogleStackDriverAppender](obj/api.Google.Logging.GoogleStackdriverAppender.yml)
+[GoogleStackDriverAppender](obj/api/Google.Logging.Log4Net.GoogleStackdriverAppender.yml)
 provides a [log4net](https://logging.apache.org/log4net/) appender to log messages
 to Google Stackdriver Logging.
 

--- a/src/Google.Logging.Log4Net/GoogleStackdriverAppender.cs
+++ b/src/Google.Logging.Log4Net/GoogleStackdriverAppender.cs
@@ -26,12 +26,11 @@ using System.Threading.Tasks;
 namespace Google.Logging.Log4Net
 {
     /// <summary>
-    /// Appends logging events to <see cref="https://cloud.google.com/stackdriver/">Google Stackdriver Logging</see>.
+    /// Appends logging events to Google Stackdriver Logging.
     /// </summary>
     /// <remarks>
-    /// Logging events are sent to
-    /// <see cref="https://cloud.google.com/stackdriver/">Google Stackdriver Logging</see>
-    /// asychronously, via a local buffer. This  is to ensure that server errors or increased
+    /// Logging events are sent to Google Stackdriver Logging asychronously,
+    /// via a local buffer. This  is to ensure that server errors or increased
     /// network/server latency don't cause slow-downs in the program being logged.
     /// TODO: Explain all the configuration options.
     /// </remarks>

--- a/tools/Google.GCloud.Tools.GenerateSnippetMarkdown/Program.cs
+++ b/tools/Google.GCloud.Tools.GenerateSnippetMarkdown/Program.cs
@@ -321,6 +321,10 @@ namespace Google.GCloud.Tools.GenerateSnippetMarkdown
 
         private static void GenerateSnippetMarkdown(string outputFile, string relativeSnippetFile, IEnumerable<Snippet> snippets)
         {
+            if (!snippets.SelectMany(snippet => snippet.MetadataUids).Any())
+            {
+                return;
+            }
             using (var writer = File.CreateText(outputFile))
             {
                 foreach (var snippet in snippets)


### PR DESCRIPTION
- Fix link in index.md
- Remove http crefs in XML docs. (Basically there's no standard
  way of linking to external docs. Sucks.)
- Handle the case where a snippet file only has samples, not snippets; docfx
  fails if we generate an empty .md file (as we used to)