### PR TITLE
Stop deleting logs when the logging snippet finishes.

### DIFF
--- a/snippets/Google.Logging.Log4Net.Snippets/Log4NetSnippetFixture.cs
+++ b/snippets/Google.Logging.Log4Net.Snippets/Log4NetSnippetFixture.cs
@@ -25,7 +25,7 @@ namespace Google.Logging.Log4Net.Snippets
 
         public string ProjectId { get; }
 
-        public string LogId { get; } = "TestLog";
+        public string LogId { get; } = "Log4NetTestLog";
 
         public Log4NetSnippetFixture()
         {
@@ -39,9 +39,9 @@ namespace Google.Logging.Log4Net.Snippets
 
         public void Dispose()
         {
-            var logging = LoggingServiceV2Client.Create();
-            var logName = LoggingServiceV2Client.FormatLogName(ProjectId, LogId);
-            logging.DeleteLog(logName);
+            // No clean-up here, because:
+            // - We can't assert log entries in tests, so it's useful to be able to check them manually later.
+            // - If the log entries haven't arrived yet, deleting them would cause an exception anyway.
         }
     }
 }

--- a/snippets/Google.Logging.Log4Net.Snippets/project.json
+++ b/snippets/Google.Logging.Log4Net.Snippets/project.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "Google.Logging.Log4Net": "",
     "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-rc1-build204",
+    "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
 
   "commands": {


### PR DESCRIPTION
This avoids an exception, and makes manual verification simpler.

(At the same time, remove an annoying trailing comma from
project.json.)