### PR TITLE
Show the XML file used in log4net configuration as a plain file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -105,6 +105,14 @@ to Google Stackdriver Logging.
 
 Simple logging:
 
+First create a `log4net` configuration file (`log4net.xml`) as below:
+
+[!code-xml[](obj/snippets/Google.Logging.Log4Net.GoogleStackdriverAppender.txt#log4net_template)]
+
+Edit the file replacing `PROJECT_ID` with your Google Cloud Project
+ID, and `LOG_ID` with an identifier for your application. Use this
+file to configure `log4net` and then log as normal.
+
 [!code-cs[](obj/snippets/Google.Logging.Log4Net.GoogleStackdriverAppender.txt#Overview)]
 
 See the

--- a/snippets/Google.Logging.Log4Net.Snippets/log4net-template.xml
+++ b/snippets/Google.Logging.Log4Net.Snippets/log4net-template.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+  <appender name="CloudLogger" type="Google.Logging.Log4Net.GoogleStackdriverAppender,Google.Logging.Log4Net">
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%-4timestamp [%thread] %-5level %logger %ndc - %message"/>
+    </layout>
+    <projectId value="PROJECT_ID"/>
+    <logId value="LOG_ID"/>
+  </appender>
+  <root>
+    <level value="ALL"/>
+    <appender-ref ref="CloudLogger"/>
+  </root>
+</log4net>

--- a/snippets/Google.Logging.Log4Net.Snippets/project.json
+++ b/snippets/Google.Logging.Log4Net.Snippets/project.json
@@ -11,6 +11,10 @@
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
 
+  "resource": [
+    "log4net-template.xml"
+  ],
+
   "commands": {
     "test": "xunit.runner.dnx"
   },


### PR DESCRIPTION
First commit is for the snippet generator; second commit uses the changes.